### PR TITLE
PKCE user authentication

### DIFF
--- a/docs/src/advanced_usage.rst
+++ b/docs/src/advanced_usage.rst
@@ -9,60 +9,96 @@ Authorisation methods
 *********************
 There are many authorisation options for both applications and users.
 Here's a summary, see :ref:`auth` for more details.
+Class names are abbreviated as :class:`C` and :class:`RC` for brevity.
 
-- **Subject**: is the resulting token an application or user token
 - **Creation**: is the method for generating new tokens or refreshing them
 - **Type**: is the resulting token expiring or automatically refreshing
 
-.. |exp-app-new| replace:: :meth:`Credentials.request_client_token`
-.. |exp-usr-new| replace:: :meth:`Credentials.request_user_token`
-.. |exp-usr-ref| replace:: :meth:`Credentials.refresh_user_token`
-.. |exp-a-u-ref| replace:: :meth:`Credentials.refresh`
-.. |ref-app-new| replace:: :meth:`RefreshingCredentials.request_client_token`
-.. |ref-usr-new| replace:: :meth:`RefreshingCredentials.request_user_token`
-.. |ref-usr-ref| replace:: :meth:`RefreshingCredentials.refresh_user_token`
+.. |exp-app-new| replace::
+   :meth:`C.request_client_token <Credentials.request_client_token>`
+.. |exp-usr-new| replace::
+   :meth:`C.request_user_token <Credentials.request_user_token>`
+.. |exp-usr-ref| replace::
+   :meth:`C.refresh_user_token <Credentials.refresh_user_token>`
+.. |exp-pkc-new| replace::
+   :meth:`C.request_pkce_token <Credentials.request_pkce_token>`
+.. |exp-pkc-ref| replace::
+   :meth:`C.refresh_pkce_token <Credentials.refresh_pkce_token>`
+.. |exp-a-u-ref| replace::
+   :meth:`C.refresh <Credentials.refresh>`
+.. |ref-app-new| replace::
+   :meth:`RC.request_client_token <RefreshingCredentials.request_client_token>`
+.. |ref-usr-new| replace::
+   :meth:`RC.request_user_token <RefreshingCredentials.request_user_token>`
+.. |ref-usr-ref| replace::
+   :meth:`RC.refresh_user_token <RefreshingCredentials.refresh_user_token>`
+.. |ref-pkc-new| replace::
+   :meth:`RC.request_pkce_token <Credentials.request_pkce_token>`
+.. |ref-pkc-ref| replace::
+   :meth:`RC.refresh_pkce_token <Credentials.refresh_pkce_token>`
 .. |utl-app-new| replace:: :func:`request_client_token`
 .. |utl-usr-new| replace:: :func:`prompt_for_user_token`
 .. |utl-usr-ref| replace:: :func:`refresh_user_token`
+.. |utl-pkc-new| replace:: :func:`prompt_for_pkce_token`
+.. |utl-pkc-ref| replace:: :func:`refresh_pkce_token`
 
-+----------+----------+------------+-------+---------------+
-| Subject  | Creation | Type       | Notes | Method        |
-+==========+==========+============+=======+===============+
-| App      | New      | Expiring   |       | |exp-app-new| |
-+----------+----------+------------+-------+---------------+
-| User     | New      | Expiring   | 1     | |exp-usr-new| |
-+----------+----------+------------+-------+---------------+
-| User     | Refresh  | Expiring   |       | |exp-usr-ref| |
-+----------+----------+------------+-------+---------------+
-| A+U      | Refresh  | Expiring   | 2     | |exp-a-u-ref| |
-+----------+----------+------------+-------+---------------+
-| App      | New      | Refreshing |       | |ref-app-new| |
-+----------+----------+------------+-------+---------------+
-| User     | New      | Refreshing | 1     | |ref-usr-new| |
-+----------+----------+------------+-------+---------------+
-| User     | Refresh  | Refreshing |       | |ref-usr-ref| |
-+----------+----------+------------+-------+---------------+
-| App      | New      | Refreshing | 3     | |utl-app-new| |
-+----------+----------+------------+-------+---------------+
-| User     | New      | Refreshing | 3, 4  | |utl-usr-new| |
-+----------+----------+------------+-------+---------------+
-| User     | Refresh  | Refreshing | 3     | |utl-usr-ref| |
-+----------+----------+------------+-------+---------------+
+**Application tokens**
+
++----------+------------+-------+---------------+
+| Creation | Type       | Notes | Method        |
++==========+============+=======+===============+
+| New      | Expiring   |       | |exp-app-new| |
++----------+------------+-------+---------------+
+| Refresh  | Expiring   | 1     | |exp-a-u-ref| |
++----------+------------+-------+---------------+
+| New      | Refreshing |       | |ref-app-new| |
++----------+------------+-------+---------------+
+| New      | Refreshing | 2     | |utl-app-new| |
++----------+------------+-------+---------------+
+
+**User tokens**
+
+There are two variants of each user authorisation method.
+One uses ordinary OAuth 2 authorisation, the other its PKCE extension
+which is more secure for public clients at the cost of convenience.
+
++----------+------------+-------+---------------+---------------+
+| Creation | Type       | Notes | Ordinary      | PKCE variant  |
++==========+============+=======+===============+===============+
+| New      | Expiring   | 3     | |exp-usr-new| | |exp-pkc-new| |
++----------+------------+-------+---------------+---------------+
+| Refresh  | Expiring   |       | |exp-usr-ref| | |exp-pkc-new| |
++----------+------------+-------+---------------+---------------+
+| Refresh  | Expiring   | 1     | |exp-a-u-ref| | |exp-a-u-ref| |
++----------+------------+-------+---------------+---------------+
+| New      | Refreshing | 3     | |ref-usr-new| | |ref-pkc-new| |
++----------+------------+-------+---------------+---------------+
+| Refresh  | Refreshing |       | |ref-usr-ref| | |ref-pkc-ref| |
++----------+------------+-------+---------------+---------------+
+| New      | Refreshing | 2, 4  | |utl-usr-new| | |utl-pkc-new| |
++----------+------------+-------+---------------+---------------+
+| Refresh  | Refreshing | 2     | |utl-usr-ref| | |utl-pkc-ref| |
++----------+------------+-------+---------------+---------------+
+
+:class:`UserAuth` can be used to simplify the implementation of user
+authorisation with either one of the credentials clients, with or without PKCE.
 
 **Notes**
 
-1. These methods are paired with the first step of user authorisation:
-   redirecting the user to a URL to login with Spotify.
-2. This is a subject-agnostic refresh, fit for both app and user tokens.
+1. This is a subject-agnostic refresh,
+   fit for both app and user tokens with or without PKCE.
    For application tokens, a new token is returned.
-3. These methods wrap around :class:`RefreshingCredentials` internally.
+2. These functions wrap around :class:`RefreshingCredentials` internally
+   to provide a shorthand for one-off authorisation.
+3. These methods are paired with the first step of user authorisation:
+   redirecting the user to a URL to login with Spotify.
 4. Requires manually pasting text to a terminal, is not usable on a server.
-
-:class:`UserAuth` can be used to simplify the implementation
-of user authorisation with either one of the credentials clients.
 
 Security
 ********
+There are two main security concerns with authorisation,
+besides the obvious leaking of access tokens.
+
 Using a state with user authorisation prevents cross-site request forgery
 (`RFC 6749 <https://tools.ietf.org/html/rfc6749#section-10.12>`_).
 A string can be sent as state on authorisation.
@@ -71,6 +107,30 @@ the same state should be returned as a query parameter.
 :func:`gen_state` is provided to generate random strings to send as state.
 :func:`parse_state_from_url` can then be used to extract the returned state.
 State is generated and checked automatically when using :class:`UserAuth`.
+
+A client secret might not always be safe
+and the redirect URI handler might be vulnerable
+(`RFC 7636 <https://tools.ietf.org/html/rfc7636>`_).
+The PKCE extension to user authorisation allows
+retrieving user tokens without a client secret,
+and provides an added layer of security with code challenges and verifiers.
+Challenges and verifiers are handled automatically when using
+:class:`UserAuth` with PKCE enabled.
+Here's a summary of the requirements for each authorisation method.
+
++-------------------------+-----------+---------------+--------------+
+| Method                  | Client ID | Client secret | Redirect URI |
++=========================+===========+===============+==============+
+| Client authorisation    | x         | x             |              |
++-------------------------+-----------+---------------+--------------+
+| User authorisation      | x         | x             | x            |
++-------------------------+-----------+---------------+--------------+
+| User token refresh      | x         | x             |              |
++-------------------------+-----------+---------------+--------------+
+| PKCE user authorisation | x         |               | x            |
++-------------------------+-----------+---------------+--------------+
+| PKCE token refresh      | x         |               |              |
++-------------------------+-----------+---------------+--------------+
 
 Expanding scopes
 ****************

--- a/docs/src/reference/auth.rst
+++ b/docs/src/reference/auth.rst
@@ -19,6 +19,8 @@ Web API authorisation.
    request_client_token
    prompt_for_user_token
    refresh_user_token
+   prompt_for_pkce_token
+   refresh_pkce_token
    UserAuth
    gen_state
    parse_code_from_url
@@ -86,6 +88,12 @@ Access tokens can also be retrieved without instantiating
 For that purpose, a number of `utilities`_ are provided.
 They also include other useful constructs related to authorisation.
 
+User authorisation can be performed using Proof Key for Code Exchange,
+an extension to ordinary user authorisation.
+It is more secure for public clients, but a refresh token can only be used
+to spawn the next token, after which it is invalidated.
+Still, all tokens are valid for their full duration.
+
 Expiring credentials
 --------------------
 .. autoclass:: Credentials
@@ -142,6 +150,8 @@ Authorisation utilities.
    request_client_token
    prompt_for_user_token
    refresh_user_token
+   prompt_for_pkce_token
+   refresh_pkce_token
    UserAuth
    gen_state
    parse_code_from_url
@@ -150,6 +160,8 @@ Authorisation utilities.
 .. autofunction:: request_client_token
 .. autofunction:: prompt_for_user_token
 .. autofunction:: refresh_user_token
+.. autofunction:: prompt_for_pkce_token
+.. autofunction:: refresh_pkce_token
 .. autoclass:: UserAuth
 .. autofunction:: gen_state
 .. autofunction:: parse_code_from_url

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -15,6 +15,9 @@ Added
 - :func:`parse_state_from_url` - parse state from URL parameters (:issue:`207`)
 - :class:`UserAuth` - implement user authorisation with security checks,
   the caller simply provides the resulting URI after redirection (:issue:`207`)
+- :ref:`auth` - PKCE can be used in user authorisation, providing added
+  security for public clients by removing the need to use a client secret.
+  (:issue:`189`)
 
 Removed
 *******

--- a/tekore/__init__.py
+++ b/tekore/__init__.py
@@ -27,6 +27,8 @@ from ._auth import (
     parse_state_from_url,
     prompt_for_user_token,
     refresh_user_token,
+    prompt_for_pkce_token,
+    refresh_pkce_token,
     request_client_token,
 )
 from ._client import Spotify

--- a/tekore/_auth/__init__.py
+++ b/tekore/_auth/__init__.py
@@ -7,7 +7,9 @@ from .util import (
     gen_state,
     parse_code_from_url,
     parse_state_from_url,
-    refresh_user_token,
     request_client_token,
     prompt_for_user_token,
+    refresh_user_token,
+    prompt_for_pkce_token,
+    refresh_pkce_token,
 )

--- a/tekore/_auth/expiring.py
+++ b/tekore/_auth/expiring.py
@@ -1,4 +1,7 @@
 from base64 import b64encode as _b64encode
+from typing import Tuple, Callable
+from hashlib import sha256
+from secrets import token_urlsafe
 
 from urllib.parse import urlencode
 
@@ -14,6 +17,13 @@ OAUTH_TOKEN_URL = 'https://accounts.spotify.com/api/token'
 def b64encode(msg: str) -> str:
     """Encode a unicode string in base-64."""
     return _b64encode(msg.encode()).decode()
+
+
+def b64urlencode(msg: bytes) -> str:
+    """Encode bytes in url-safe base-64 alphabet."""
+    encoded = _b64encode(msg).decode()
+    stripped = encoded.split("=")[0]
+    return stripped.replace("+", "-").replace("/", "_")
 
 
 def handle_errors(request: Request, response: Response) -> None:
@@ -33,38 +43,43 @@ def handle_errors(request: Request, response: Response) -> None:
     raise error_cls(error_str, request=request, response=response)
 
 
-def parse_token(request: Request, response: Response) -> Token:
-    """Parse token object from response."""
-    handle_errors(request, response)
-    return Token(response.content)
+def parse_token(uses_pkce: bool) -> Callable:
+    """Wrap token parsing conditional to PKCE usage."""
+    def func(request: Request, response: Response) -> Token:
+        """Parse token object from response."""
+        handle_errors(request, response)
+        return Token(response.content, uses_pkce)
+    return func
 
 
-def parse_refreshed_token(
-    request: Request, response: Response, refresh_token: str
-) -> Token:
-    """Replace new refresh token with old value if empty."""
-    refreshed = parse_token(request, response)
+def parse_refreshed_token(uses_pkce: bool) -> Callable:
+    """Wrap token parsing conditional to PKCE usage."""
+    def func(
+        request: Request, response: Response, refresh_token: str
+    ) -> Token:
+        """Replace new refresh token with old value if empty."""
+        handle_errors(request, response)
+        refreshed = Token(response.content, uses_pkce)
 
-    if refreshed.refresh_token is None:
-        refreshed._refresh_token = refresh_token
+        if refreshed.refresh_token is None:
+            refreshed._refresh_token = refresh_token
 
-    return refreshed
+        return refreshed
+    return func
 
 
 class Credentials(Client):
     """
     Client for retrieving access tokens.
 
-    Specifying a ``redirect_uri`` is required only when authorising users.
-
     Parameters
     ----------
     client_id
         client id
     client_secret
-        client secret
+        client secret, not required for PKCE user authorisation
     redirect_uri
-        whitelisted redirect URI
+        whitelisted redirect URI, required for user authorisation
     sender
         request sender
     asynchronous
@@ -74,7 +89,7 @@ class Credentials(Client):
     def __init__(
         self,
         client_id: str,
-        client_secret: str,
+        client_secret: str = None,
         redirect_uri: str = None,
         sender: Sender = None,
         asynchronous: bool = None,
@@ -93,15 +108,16 @@ class Credentials(Client):
         ]
         return type(self).__name__ + '(' + ', '.join(options) + ')'
 
-    @property
-    def _auth(self) -> str:
-        return b64encode(self.client_id + ':' + self.client_secret)
+    def _token_request(self, payload: dict, auth: bool) -> Request:
+        if auth:
+            token = b64encode(self.client_id + ':' + self.client_secret)
+            headers = {'Authorization': f'Basic {token}'}
+        else:
+            headers = None
 
-    def _token_request(self, payload: dict):
-        headers = {'Authorization': f'Basic {self._auth}'}
         return Request('POST', OAUTH_TOKEN_URL, data=payload, headers=headers)
 
-    @send_and_process(parse_token)
+    @send_and_process(parse_token(uses_pkce=False))
     def request_client_token(self) -> Token:
         """
         Request a client token.
@@ -112,7 +128,21 @@ class Credentials(Client):
             client access token
         """
         payload = {'grant_type': 'client_credentials'}
-        return self._token_request(payload), ()
+        return self._token_request(payload, auth=True), ()
+
+    def _user_auth_payload(self, scope, state):
+        payload = {
+            'client_id': self.client_id,
+            'redirect_uri': self.redirect_uri,
+            'response_type': 'code',
+        }
+        if isinstance(scope, list):
+            scope = Scope(*scope)
+        if scope is not None:
+            payload['scope'] = str(scope)
+        if state is not None:
+            payload['state'] = state
+        return payload
 
     def user_authorisation_url(
         self,
@@ -125,6 +155,7 @@ class Credentials(Client):
 
         Step 1/2 in authorisation code flow.
         User should be redirected to the resulting URL for authorisation.
+        Step 2/2: :meth:`request_user_token`.
 
         Parameters
         ----------
@@ -142,29 +173,18 @@ class Credentials(Client):
         str
             login URL
         """
-        payload = {
-            'show_dialog': str(show_dialog).lower(),
-            'client_id': self.client_id,
-            'response_type': 'code',
-            'redirect_uri': self.redirect_uri
-        }
-        if isinstance(scope, list):
-            scope = Scope(*scope)
-        if scope is not None:
-            payload['scope'] = str(scope)
-        if state is not None:
-            payload['state'] = state
-
+        payload = self._user_auth_payload(scope, state)
+        payload['show_dialog'] = str(show_dialog).lower()
         return OAUTH_AUTHORIZE_URL + '?' + urlencode(payload)
 
-    @send_and_process(parse_token)
+    @send_and_process(parse_token(uses_pkce=False))
     def request_user_token(self, code: str) -> Token:
         """
         Request a new user token.
 
         Step 2/2 in authorisation code flow.
         Code is provided as a URL parameter in the redirect URI
-        after login in step 1.
+        after login in step 1: :meth:`user_authorisation_url`.
 
         Parameters
         ----------
@@ -181,9 +201,9 @@ class Credentials(Client):
             'redirect_uri': self.redirect_uri,
             'grant_type': 'authorization_code'
         }
-        return self._token_request(payload), ()
+        return self._token_request(payload, auth=True), ()
 
-    @send_and_process(parse_refreshed_token)
+    @send_and_process(parse_refreshed_token(uses_pkce=False))
     def refresh_user_token(self, refresh_token: str) -> Token:
         """
         Request a refreshed user token.
@@ -202,13 +222,110 @@ class Credentials(Client):
             'refresh_token': refresh_token,
             'grant_type': 'refresh_token'
         }
-        return self._token_request(payload), (refresh_token,)
+        return self._token_request(payload, auth=True), (refresh_token,)
+
+    def pkce_user_authorisation(
+        self,
+        scope=None,
+        state: str = None,
+        verifier_bytes: int = 32,
+    ) -> Tuple[str, str]:
+        """
+        Construct authorisation URL and verifier.
+
+        Step 1/2 in authorisation code flow with proof key for code exchange.
+        The user should be redirected to the resulting URL for authorisation.
+        The verifier is passed to :meth:`request_pkce_token` in step 2.
+
+        Parameters
+        ----------
+        scope
+            token privileges, accepts a :class:`Scope`, a single :class:`scope`,
+            a list of :class:`scopes <scope>` and strings for :class:`Scope`,
+            or a space-separated list of scopes as a string
+        state
+            additional state
+        verifier_bytes
+            number of bytes to generate PKCE verifier with, ``32 <= bytes <= 96``.
+            The specified range of bytes generates the appropriate number of
+            characters (43 - 128) after base-64 encoding, as required in RFC 7636.
+
+        Returns
+        -------
+        Tuple[str, str]
+            authorisation URL and PKCE code verifier
+        """
+        assert 32 <= verifier_bytes <= 96
+        verifier = token_urlsafe(verifier_bytes)
+
+        sha = sha256(verifier.encode())
+        challenge = b64urlencode(sha.digest())
+
+        payload = self._user_auth_payload(scope, state)
+        payload['code_challenge'] = challenge
+        payload['code_challenge_method'] = 'S256'
+
+        auth_url = OAUTH_AUTHORIZE_URL + '?' + urlencode(payload)
+        return auth_url, verifier
+
+    @send_and_process(parse_token(uses_pkce=True))
+    def request_pkce_token(self, code: str, verifier: str) -> Token:
+        """
+        Request a new PKCE user token.
+
+        Step 2/2 in authorisation code flow with proof key for code exchange.
+        Code is provided as a URL parameter in the redirect URI
+        after login in step 1: :meth:`pkce_user_authorisation`.
+
+        Parameters
+        ----------
+        code
+            code from redirect parameters
+        verifier
+            PKCE code verifier generated for authorisation URL
+
+        Returns
+        -------
+        Token
+            user access token
+        """
+        payload = {
+            'client_id': self.client_id,
+            'code': code,
+            'code_verifier': verifier,
+            'grant_type': 'authorization_code',
+            'redirect_uri': self.redirect_uri,
+        }
+        return self._token_request(payload, auth=False), ()
+
+    @send_and_process(parse_refreshed_token(uses_pkce=True))
+    def refresh_pkce_token(self, refresh_token: str) -> Token:
+        """
+        Request a refreshed PKCE user token.
+
+        Parameters
+        ----------
+        refresh_token
+            refresh token
+
+        Returns
+        -------
+        Token
+            refreshed user access token
+        """
+        payload = {
+            'client_id': self.client_id,
+            'grant_type': 'refresh_token',
+            'refresh_token': refresh_token,
+        }
+        return self._token_request(payload, auth=False), (refresh_token,)
 
     def refresh(self, token: Token) -> Token:
         """
         Refresh an access token.
 
         Both client and user tokens are accepted and refreshed.
+        The correct refreshing method is applied regardless if PKCE was used or not.
         For client tokens, a new token is returned.
         For user tokens, a refreshed token is returned.
 
@@ -224,5 +341,7 @@ class Credentials(Client):
         """
         if token.refresh_token is None:
             return self.request_client_token()
+        elif token.uses_pkce:
+            return self.refresh_pkce_token(token.refresh_token)
         else:
             return self.refresh_user_token(token.refresh_token)

--- a/tekore/_auth/expiring.py
+++ b/tekore/_auth/expiring.py
@@ -72,12 +72,12 @@ class Credentials(Client):
     """
 
     def __init__(
-            self,
-            client_id: str,
-            client_secret: str,
-            redirect_uri: str = None,
-            sender: Sender = None,
-            asynchronous: bool = None,
+        self,
+        client_id: str,
+        client_secret: str,
+        redirect_uri: str = None,
+        sender: Sender = None,
+        asynchronous: bool = None,
     ):
         super().__init__(sender, asynchronous)
         self.client_id = client_id
@@ -115,10 +115,10 @@ class Credentials(Client):
         return self._token_request(payload), ()
 
     def user_authorisation_url(
-            self,
-            scope=None,
-            state: str = None,
-            show_dialog: bool = False
+        self,
+        scope=None,
+        state: str = None,
+        show_dialog: bool = False
     ) -> str:
         """
         Construct an authorisation URL.

--- a/tekore/_auth/refreshing.py
+++ b/tekore/_auth/refreshing.py
@@ -109,11 +109,11 @@ class RefreshingCredentials:
     """
 
     def __init__(
-            self,
-            client_id: str,
-            client_secret: str,
-            redirect_uri: str = None,
-            sender: Sender = None
+        self,
+        client_id: str,
+        client_secret: str,
+        redirect_uri: str = None,
+        sender: Sender = None
     ):
         self._client = Credentials(
             client_id,
@@ -145,10 +145,10 @@ class RefreshingCredentials:
         return RefreshingToken(token, self._client)
 
     def user_authorisation_url(
-            self,
-            scope=None,
-            state: str = None,
-            show_dialog: bool = False
+        self,
+        scope=None,
+        state: str = None,
+        show_dialog: bool = False
     ) -> str:
         """
         Construct an authorisation URL.

--- a/tekore/_auth/refreshing.py
+++ b/tekore/_auth/refreshing.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Tuple
 
 from .expiring import Credentials
 from .token import AccessToken, Token
@@ -88,6 +88,11 @@ class RefreshingToken(AccessToken):
         """Determine whether token is about to expire, always ``False``."""
         return False
 
+    @property
+    def uses_pkce(self) -> bool:
+        """Proof key for code exchange used in authorisation."""
+        return self._token.uses_pkce
+
 
 class RefreshingCredentials:
     """
@@ -101,9 +106,9 @@ class RefreshingCredentials:
     client_id
         client id
     client_secret
-        client secret
+        client secret, not required for PKCE user authorisation
     redirect_uri
-        whitelisted redirect URI
+        whitelisted redirect URI, required for user authorisation
     sender
         synchronous request sender
     """
@@ -111,7 +116,7 @@ class RefreshingCredentials:
     def __init__(
         self,
         client_id: str,
-        client_secret: str,
+        client_secret: str = None,
         redirect_uri: str = None,
         sender: Sender = None
     ):
@@ -155,6 +160,7 @@ class RefreshingCredentials:
 
         Step 1/2 in authorisation code flow.
         User should be redirected to the resulting URL for authorisation.
+        Step 2/2: :meth:`request_user_token`.
 
         Parameters
         ----------
@@ -180,7 +186,7 @@ class RefreshingCredentials:
 
         Step 2/2 in authorisation code flow.
         Code is provided as a URL parameter in the redirect URI
-        after login in step 1.
+        after login in step 1: :meth:`user_authorisation_url`.
 
         Parameters
         ----------
@@ -210,4 +216,77 @@ class RefreshingCredentials:
             automatically refreshing user token
         """
         token = self._client.refresh_user_token(refresh_token)
+        return RefreshingToken(token, self._client)
+
+    def pkce_user_authorisation(
+        self,
+        scope=None,
+        state: str = None,
+        verifier_bytes: int = 32,
+    ) -> Tuple[str, str]:
+        """
+        Construct authorisation URL and verifier.
+
+        Step 1/2 in authorisation code flow with proof key for code exchange.
+        The user should be redirected to the resulting URL for authorisation.
+        The verifier is passed to :meth:`request_pkce_token` in step 2.
+
+        Parameters
+        ----------
+        scope
+            token privileges, accepts a :class:`Scope`, a single :class:`scope`,
+            a list of :class:`scopes <scope>` and strings for :class:`Scope`,
+            or a space-separated list of scopes as a string
+        state
+            additional state
+        verifier_bytes
+            number of bytes to generate PKCE verifier with, ``32 <= bytes <= 96``.
+            The specified range of bytes generates the appropriate number of
+            characters (43 - 128) after base-64 encoding, as required in RFC 7636.
+
+        Returns
+        -------
+        Tuple[str, str]
+            authorisation URL and PKCE code verifier
+        """
+        return self._client.pkce_user_authorisation(scope, state, verifier_bytes)
+
+    def request_pkce_token(self, code: str, verifier: str) -> RefreshingToken:
+        """
+        Request a new PKCE user token.
+
+        Step 2/2 in authorisation code flow with proof key for code exchange.
+        Code is provided as a URL parameter in the redirect URI
+        after login in step 1: :meth:`pkce_user_authorisation`.
+
+        Parameters
+        ----------
+        code
+            code from redirect parameters
+        verifier
+            PKCE code verifier generated for authorisation URL
+
+        Returns
+        -------
+        RefreshingToken
+            user access token
+        """
+        token = self._client.request_pkce_token(code, verifier)
+        return RefreshingToken(token, self._client)
+
+    def refresh_pkce_token(self, refresh_token: str) -> RefreshingToken:
+        """
+        Request a refreshed PKCE user token.
+
+        Parameters
+        ----------
+        refresh_token
+            refresh token
+
+        Returns
+        -------
+        RefreshingToken
+            refreshed user access token
+        """
+        token = self._client.refresh_pkce_token(refresh_token)
         return RefreshingToken(token, self._client)

--- a/tekore/_auth/token.py
+++ b/tekore/_auth/token.py
@@ -32,7 +32,7 @@ class Token(AccessToken):
     The refresh token of a client token is ``None``.
     """
 
-    def __init__(self, token_info: dict):
+    def __init__(self, token_info: dict, uses_pkce: bool):
         self._access_token = token_info['access_token']
         self._token_type = token_info['token_type']
 
@@ -42,6 +42,7 @@ class Token(AccessToken):
 
         self._refresh_token = token_info.get('refresh_token', None)
         self._expires_at = int(time.time()) + token_info['expires_in']
+        self._uses_pkce = uses_pkce
 
     def __repr__(self):
         options = [
@@ -95,3 +96,8 @@ class Token(AccessToken):
     def is_expiring(self) -> bool:
         """Determine whether token is about to expire."""
         return self.expires_in < 60
+
+    @property
+    def uses_pkce(self) -> bool:
+        """Proof key for code exchange used in authorisation."""
+        return self._uses_pkce

--- a/tekore/_auth/util.py
+++ b/tekore/_auth/util.py
@@ -153,16 +153,15 @@ class UserAuth:
 
         if self.state != state:
             raise AssertionError(
-                'Inconsistent state!'
-                f' Expected `{self.state}`, got `{state}`.'
+                f'Inconsistent state! Expected `{self.state}`, got `{state}`.'
             )
 
         return self._cred.request_user_token(code)
 
 
 def request_client_token(
-        client_id: str,
-        client_secret: str
+    client_id: str,
+    client_secret: str
 ) -> RefreshingToken:
     """
     Request for client credentials.
@@ -184,10 +183,10 @@ def request_client_token(
 
 
 def prompt_for_user_token(
-        client_id: str,
-        client_secret: str,
-        redirect_uri: str,
-        scope=None
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+    scope=None
 ) -> RefreshingToken:
     """
     Prompt for manual authorisation.
@@ -228,9 +227,9 @@ def prompt_for_user_token(
 
 
 def refresh_user_token(
-        client_id: str,
-        client_secret: str,
-        refresh_token: str
+    client_id: str,
+    client_secret: str,
+    refresh_token: str
 ) -> RefreshingToken:
     """
     Request a refreshed user token.

--- a/tests/auth/expiring.py
+++ b/tests/auth/expiring.py
@@ -1,7 +1,7 @@
 import pytest
 
 from unittest.mock import MagicMock, patch
-from tekore import HTTPError, AccessToken, Token, Credentials, Scope
+from tekore import HTTPError, AccessToken, Token, Credentials, Scope, Response
 
 
 class TestAccessToken:
@@ -19,7 +19,7 @@ class TestAccessToken:
         assert t.access_token == str(t)
 
 
-def make_token_dict():
+def token_dict():
     return {
         'access_token': 'accesstoken',
         'expires_in': 3600,
@@ -29,12 +29,18 @@ def make_token_dict():
     }
 
 
+def make_token(attrs: dict = None, uses_pkce: bool = False):
+    a = token_dict()
+    a.update(attrs or {})
+    return Token(a, uses_pkce)
+
+
 time_module = 'tekore._auth.token.time'
 
 
 class TestToken:
     def test_repr(self):
-        t = Token(make_token_dict())
+        t = make_token()
         assert repr(t).startswith('Token(')
 
     def test_access_token_returned(self):
@@ -42,7 +48,7 @@ class TestToken:
         time.time.return_value = 0
 
         with patch(time_module, time):
-            token = Token(make_token_dict())
+            token = make_token()
             assert token.access_token == 'accesstoken'
 
     def test_expires_in_set_time(self):
@@ -50,7 +56,7 @@ class TestToken:
         time.time.return_value = 0
 
         with patch(time_module, time):
-            token = Token(make_token_dict())
+            token = make_token()
             assert token.expires_in == 3600
 
     def test_expires_in_is_refreshed(self):
@@ -58,7 +64,7 @@ class TestToken:
         time.time.side_effect = [0, 1]
 
         with patch(time_module, time):
-            token = Token(make_token_dict())
+            token = make_token()
             assert token.expires_in == 3599
 
     def test_old_token_is_expiring(self):
@@ -66,37 +72,24 @@ class TestToken:
         time.time.side_effect = [0, 3600]
 
         with patch(time_module, time):
-            token = Token(make_token_dict())
+            token = make_token()
             assert token.is_expiring is True
 
     def test_token_type(self):
-        d = make_token_dict()
-        t = Token(d)
-        assert t.token_type == d['token_type']
+        t = make_token()
+        assert isinstance(t.token_type, str)
 
     def test_scope_parsed(self):
-        d = make_token_dict()
-        scope = 'a b c'
-        d['scope'] = scope
-        t = Token(d)
-
+        t = make_token()
         assert isinstance(t.scope, Scope)
-        assert str(t.scope) == scope
 
     def test_no_scope_is_empty(self):
-        d = make_token_dict()
-        scope = ''
-        d['scope'] = scope
-        t = Token(d)
-
+        t = make_token({'scope': ''})
         assert len(t.scope) == 0
 
 
 def mock_response(code: int = 200, content: dict = None) -> MagicMock:
-    response = MagicMock()
-    response.status_code = code
-    response.content = content or make_token_dict()
-    return response
+    return Response('https://url.com', {}, code, content or token_dict())
 
 
 class TestCredentialsOnline:
@@ -140,27 +133,41 @@ class TestCredentialsOffline:
     def test_credentials_initialisation(self):
         Credentials(client_id='id', client_secret='secret', redirect_uri='uri')
 
-    def test_credentials_init_redirect_uri_optional(self):
-        Credentials('id', 'secret')
+    def test_credentials_only_client_id_mandatory(self):
+        Credentials('id')
 
     def test_server_error_raises_http_error(self):
         c = Credentials('id', 'secret')
+        response = mock_response(500, {})
+        c.send = MagicMock(return_value=response)
+        with pytest.raises(HTTPError):
+            c.request_client_token()
 
-        send = MagicMock(return_value=mock_response(500))
-        with patch(cred_module + '.send', send):
-            with pytest.raises(HTTPError):
-                c.request_client_token()
+    def test_client_error_with_description(self):
+        c = Credentials('id', 'secret')
+        error = {'error': 'Bad thing', 'error_description': 'because reasons'}
+        response = mock_response(400, error)
+        c.send = MagicMock(return_value=response)
+        with pytest.raises(HTTPError):
+            c.request_client_token()
+
+    def test_client_error_without_description(self):
+        c = Credentials('id', 'secret')
+        error = {'error': 'Bad thing'}
+        response = mock_response(400, error)
+        c.send = MagicMock(return_value=response)
+        with pytest.raises(HTTPError):
+            c.request_client_token()
 
     def test_user_authorisation_url(self):
-        c = Credentials('id', 'secret', 'uri')
-        url = c.user_authorisation_url('scope', 'state', True)
+        c = Credentials('id', redirect_uri='uri')
+        url = c.user_authorisation_url('scope', 'state')
         assert 'scope=scope' in url
         assert 'state=state' in url
-        assert 'show_dialog=true' in url
 
-    def test_user_authorisation_url_accepts_scope_list(self):
-        c = Credentials('id', 'secret', 'uri')
-        url = c.user_authorisation_url(['a', 'b'], 'state', True)
+    def test_user_authorisation_accepts_scope_list(self):
+        c = Credentials('id', redirect_uri='uri')
+        url = c.user_authorisation_url(['a', 'b'], 'state')
         assert 'scope=a+b' in url
 
     def test_request_user_token(self):
@@ -171,8 +178,8 @@ class TestCredentialsOffline:
             send.assert_called_once()
 
     def test_refresh_user_token_uses_old_refresh_if_not_returned(self):
-        c = Credentials('id', 'secret', 'uri')
-        token = make_token_dict()
+        c = Credentials('id', 'secret')
+        token = token_dict()
         token['refresh_token'] = None
         response = mock_response(content=token)
 
@@ -182,8 +189,8 @@ class TestCredentialsOffline:
             assert refreshed.refresh_token == 'refresh'
 
     def test_refresh_user_token_refresh_replaced_if_returned(self):
-        c = Credentials('id', 'secret', 'uri')
-        token = make_token_dict()
+        c = Credentials('id', 'secret')
+        token = token_dict()
         response = mock_response(content=token)
 
         send = MagicMock(return_value=response)
@@ -191,22 +198,39 @@ class TestCredentialsOffline:
             refreshed = c.refresh_user_token('refresh')
             assert refreshed.refresh_token == token['refresh_token']
 
-    def test_refresh_none_refresh_interpreted_as_client_token(self):
-        c = Credentials('id', 'secret', 'uri')
-        token = MagicMock()
-        token.refresh_token = None
+    def test_pkce_user_authorisation(self):
+        c = Credentials('id', redirect_uri='redirect')
+        c.pkce_user_authorisation('scope', 'state')
 
-        mock = MagicMock()
-        with patch(cred_module + '.request_client_token', mock):
-            c.refresh(token)
-            mock.assert_called_once()
+    def test_request_pkce_token(self):
+        c = Credentials('id')
+        c.send = MagicMock(return_value=mock_response())
+        token = c.request_pkce_token('scope', 'verifier')
+        assert token.uses_pkce
 
-    def test_refresh_valid_refresh_interpreted_as_user_token(self):
-        c = Credentials('id', 'secret', 'uri')
-        token = MagicMock()
-        token.refresh_token = 'refresh'
+    def test_refresh_pkce_token(self):
+        c = Credentials('id')
+        c.send = MagicMock(return_value=mock_response())
+        token = c.refresh_pkce_token('refresh')
+        assert token.uses_pkce
 
-        mock = MagicMock()
-        with patch(cred_module + '.refresh_user_token', mock):
-            c.refresh(token)
-            mock.assert_called_once()
+    def test_auto_refresh_client_token(self):
+        c = Credentials('id', 'secret')
+        token = make_token({'refresh_token': None})
+        c.request_client_token = MagicMock(return_value=token)
+        c.refresh(token)
+        c.request_client_token.assert_called_once()
+
+    def test_auto_refresh_user_token(self):
+        c = Credentials('id', 'secret')
+        token = make_token(uses_pkce=False)
+        c.refresh_user_token = MagicMock(return_value=token)
+        c.refresh(token)
+        c.refresh_user_token.assert_called_once()
+
+    def test_auto_refresh_pkce_token(self):
+        c = Credentials('id')
+        token = make_token(uses_pkce=True)
+        c.refresh_pkce_token = MagicMock(return_value=token)
+        c.refresh(token)
+        c.refresh_pkce_token.assert_called_once()

--- a/tests/auth/refreshing.py
+++ b/tests/auth/refreshing.py
@@ -35,7 +35,7 @@ class TestRefreshingToken:
 
     def test_refreshing_token_has_same_attributes_as_regular(self):
         token_info = MagicMock()
-        token = Token(token_info)
+        token = Token(token_info, uses_pkce=False)
         token._expires_at = 3000
         auto_token = RefreshingToken(token, MagicMock())
 
@@ -48,7 +48,7 @@ class TestRefreshingToken:
 
     def test_refreshing_token_expiration_attributes(self):
         token_info = MagicMock()
-        token = Token(token_info)
+        token = Token(token_info, uses_pkce=False)
         token._expires_at = 0
 
         auto_token = RefreshingToken(token, MagicMock())


### PR DESCRIPTION
Add PKCE user authorisation.

Closes #189

- [x] Tests written with 100% coverage
- [x] Documentation and changelog entry written
- [x] All `tox` checks passed with an appropriately configured
  [environment](https://github.com/felix-hilden/tekore#running-tests)

<strike>Tests fail currently because access tokens cannot be refreshed in the same way. The refresh token in the environment needs to be generated with the new method.</strike>