### PR TITLE
Add examples to search documentation

### DIFF
--- a/tekore/_client/api/search.py
+++ b/tekore/_client/api/search.py
@@ -80,6 +80,12 @@ class SpotifySearch(SpotifyBase):
             tracks, = spotify.search('monty python')
             artists, = spotify.search('sheeran', types=('artist',))
             albums, tracks = spotify.search('piano', types=('album', 'track'))
+            spotify.search('gold album:boba artist:abba', types=('track',))
+            spotify.search('bob year:1980-2020', types=('show',))
+
+        .. note::
+            You can narrow down search results by specifying filed filters (e.g. year range, genre).
+            See the `Search for an Item <https://developer.spotify.com/documentation/web-api/reference/>` page of the official documentation for more information.
         """
         return self._get(
             'search',

--- a/tekore/_client/api/search.py
+++ b/tekore/_client/api/search.py
@@ -84,8 +84,12 @@ class SpotifySearch(SpotifyBase):
             spotify.search('bob year:1980-2020', types=('show',))
 
         .. note::
-            You can narrow down search results by specifying filed filters (e.g. year range, genre).
-            See the `Search for an Item <https://developer.spotify.com/documentation/web-api/reference/>` page of the official documentation for more information.
+            You can narrow down search results by specifying filed filters
+            (e.g. year range, genre).
+            See the `Search for an Item
+            <https://developer.spotify.com/documentation/web-api/reference/>`
+            page of the official documentation for more information.
+
         """
         return self._get(
             'search',

--- a/tekore/_client/api/search.py
+++ b/tekore/_client/api/search.py
@@ -84,7 +84,7 @@ class SpotifySearch(SpotifyBase):
             spotify.search('bob year:1980-2020', types=('show',))
 
         .. note::
-            You can narrow down search results by specifying filed filters
+            You can narrow down search results by specifying field filters
             (e.g. year range, genre).
             See the `Search for an Item
             <https://developer.spotify.com/documentation/web-api/reference/>`


### PR DESCRIPTION
Added two examples to Search API with queries that include filter fields, and added the link to the Search for an Item page in the official docs which provides more info on how to write queries.