### PR TITLE
fixes bug in conf.py

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 _root = Path(os.path.realpath(__file__)).parent.parent.parent
-sys.path.insert(0, _root)
+sys.path.insert(0, str(_root))
 
 
 project = 'tekore'


### PR DESCRIPTION
Path gets added as PosixPath instead of string, which results in: 'PosixPath' object has no attribute 'rstrip', and leaves one unable to compile the docs.

This explicitly converts the path to a string and thus fixes the issue

- [x] Tests written with 100% coverage
- [x] Documentation and changelog entry written
- [ ] All `tox` checks passed with an appropriately configured
  [environment](https://github.com/felix-hilden/tekore#running-tests)
