### PR TITLE
Fix nullable playlist owner attribute

### DIFF
--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -3,6 +3,13 @@
 
 Release notes
 =============
+Unreleased
+----------
+Fixed
+*****
+- :meth:`featured_playlists <Spotify.featured_playlists>` - allow missing
+  owner in :class:`Playlist <model.Playlist>` models (:issue:`212`)
+
 3.0.0 (2020-09-03)
 ------------------
 The next major iteration of Tekore brings fewer breaking changes than in 2.0,

--- a/tekore/_model/playlist.py
+++ b/tekore/_model/playlist.py
@@ -107,7 +107,8 @@ class Playlist(Item):
 
     def __post_init__(self):
         self.images = ModelList(Image(**i) for i in self.images)
-        self.owner = PublicUser(**self.owner)
+        if self.owner is not None:
+            self.owner = PublicUser(**self.owner)
 
 
 @dataclass(repr=False)

--- a/tekore/_model/playlist.py
+++ b/tekore/_model/playlist.py
@@ -93,7 +93,11 @@ class PlaylistTrackPaging(OffsetPaging):
 
 @dataclass(repr=False)
 class Playlist(Item):
-    """Playlist base."""
+    """
+    Playlist base.
+
+    :attr:`owner` can be ``None`` on featured playlists.
+    """
 
     collaborative: bool
     external_urls: dict


### PR DESCRIPTION
This commit fixes playlist owner attribute potentially being null in `Playlist.__post_init__`.

Related issue: #212 

- [x] Tests written with 100% coverage
- [x] Documentation and changelog entry written
- [x] All `tox` checks passed with an appropriately configured
  [environment](https://github.com/felix-hilden/tekore#running-tests)
