### PR TITLE
Ignore parameters in from_url()

### DIFF
--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -8,6 +8,7 @@ Unreleased
 Added
 *****
 - :ref:`conversions` - Ignore GET parameters in :func:`from_url` (:issue:`226`)
+
 Fixed
 *****
 - :ref:`client` - document new behavior of track markets (:issue:`228`)

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -7,7 +7,7 @@ Unreleased
 ----------
 Added
 *****
-- :ref:`conversions` - Ignore GET parameters in :func:`from_url` (:issue:`226`)
+- :ref:`conversions` - Ignore URL parameters in :func:`from_url` (:issue:`226`)
 
 Fixed
 *****

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -5,6 +5,9 @@ Release notes
 =============
 Unreleased
 ----------
+Added
+*****
+- :ref:`conversions` - Ignore GET parameters in :func:`from_url` (:issue:`226`)
 Fixed
 *****
 - :ref:`client` - document new behavior of track markets (:issue:`228`)

--- a/tekore/_convert.py
+++ b/tekore/_convert.py
@@ -141,6 +141,9 @@ def from_url(url: str) -> Tuple[str, str]:
     """
     Parse type and ID from an URL.
 
+    The query parameters used for tracking sharing of links 
+    we be stripped away (.e.g. ?si=Gwpd4fnkSNSFp_9O2hEgbD)
+
     Parameters
     ----------
     url

--- a/tekore/_convert.py
+++ b/tekore/_convert.py
@@ -162,7 +162,7 @@ def from_url(url: str) -> Tuple[str, str]:
     *prefixes, type_, id_ = url.split('/')
     prefix = '/'.join(prefixes)
 
-    id_, _ = id_.split('?si=')
+    id_ = id_.split('?si=')[0]
 
     if prefix not in _url_prefixes:
         raise ConversionError(f'Invalid URL prefix "{prefix}"!')

--- a/tekore/_convert.py
+++ b/tekore/_convert.py
@@ -141,7 +141,7 @@ def from_url(url: str) -> Tuple[str, str]:
     """
     Parse type and ID from an URL.
 
-    If the URL includes the tracking token (?si=x) 
+    If the URL includes the tracking token (?si=x)
     it will be stripped away.
 
     Parameters

--- a/tekore/_convert.py
+++ b/tekore/_convert.py
@@ -141,8 +141,7 @@ def from_url(url: str) -> Tuple[str, str]:
     """
     Parse type and ID from an URL.
 
-    If the URL includes the tracking token (?si=x)
-    it will be stripped away.
+    Any parameters in the URL will be ignored.
 
     Parameters
     ----------
@@ -162,7 +161,7 @@ def from_url(url: str) -> Tuple[str, str]:
     *prefixes, type_, id_ = url.split('/')
     prefix = '/'.join(prefixes)
 
-    id_ = id_.split('?si=')[0]
+    id_ = id_.split('?')[0]
 
     if prefix not in _url_prefixes:
         raise ConversionError(f'Invalid URL prefix "{prefix}"!')

--- a/tekore/_convert.py
+++ b/tekore/_convert.py
@@ -141,8 +141,8 @@ def from_url(url: str) -> Tuple[str, str]:
     """
     Parse type and ID from an URL.
 
-    The query parameters used for tracking sharing of links 
-    we be stripped away (.e.g. ?si=Gwpd4fnkSNSFp_9O2hEgbD)
+    If the URL includes the tracking token (?si=x) 
+    it will be stripped away.
 
     Parameters
     ----------
@@ -162,7 +162,7 @@ def from_url(url: str) -> Tuple[str, str]:
     *prefixes, type_, id_ = url.split('/')
     prefix = '/'.join(prefixes)
 
-    id_ = id_.split("?")[0]
+    id_, _ = id_.split('?si=')
 
     if prefix not in _url_prefixes:
         raise ConversionError(f'Invalid URL prefix "{prefix}"!')

--- a/tekore/_convert.py
+++ b/tekore/_convert.py
@@ -159,6 +159,8 @@ def from_url(url: str) -> Tuple[str, str]:
     *prefixes, type_, id_ = url.split('/')
     prefix = '/'.join(prefixes)
 
+    id_ = id_.split("?")[0]
+
     if prefix not in _url_prefixes:
         raise ConversionError(f'Invalid URL prefix "{prefix}"!')
     check_type(type_)

--- a/tests/convert.py
+++ b/tests/convert.py
@@ -110,3 +110,7 @@ class TestFromURL:
         url = 'a.suspicious.site/track/b62'
         with pytest.raises(ConversionError):
             self._call(url, 'track', 'b62')
+
+    def test_params(self):
+        url = 'https://open.spotify.com/track/b62?si=a101'
+        assert self._call(url, 'track', 'b62') is True


### PR DESCRIPTION
At some point Spotify started added a ?si= parameter in URLs copied from the client. From what I can see it's a way for them to track how links are shared. 

This change is to strip that away when calling from_url().

Currently `tk.from_url("https://open.spotify.com/track/08fMRujpKhEDTanKN9l2ud?si=Fwpd3fCkSNSFp_9O2hEgbQ")` results in a `tekore.ConversionError: Invalid id: "08fMRujpKhEDTanKN9l2ud?si=Fwpd3fCkSNSFp_9O2hEgbQ"!` error.

- [x] Tests written with 100% coverage
- [x] Documentation and changelog entry written
- [x] All `tox` checks passed with an appropriately configured
  [environment](https://github.com/felix-hilden/tekore#running-tests)

PS: 1 test actually fails, but I don't think it's related to this change since it's related to markets. 
```
____________________________________________________________________ TestSpotifyTrack.test_tracks_with_market _____________________________________________________________________

self = <tests.client.track.TestSpotifyTrack object at 0x7f4510fe97f0>
app_client = Spotify(token=Token(access_token='-Y'...083011, scope=Scope('')), max_limits_on=False, chunked_on=False, sender=RetryingSender(retries=0, sender=SyncSender()))

    def test_tracks_with_market(self, app_client):
        tracks = app_client.tracks(track_ids, market='US')
        assert len(tracks) == len(track_ids)
>       assert all(track.available_markets is None for track in tracks)
E       assert False
E        +  where False = all(<generator object TestSpotifyTrack.test_tracks_with_market.<locals>.<genexpr> at 0x7f45119b5120>)

tests/client/track.py:42: AssertionError
============================================================================= short test summary info =============================================================================
FAILED tests/client/track.py::TestSpotifyTrack::test_tracks_with_market - assert False
```