### PR TITLE
Update docstring for recommendations()

### DIFF
--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -7,8 +7,8 @@ Unreleased
 ----------
 Fixed
 *****
-- :ref:`client` - Update documentation for :func:`Spotify.recommendations`
-  (:issue:`229`)
+- :ref:`client` - Document the need for at least one seed in
+  :meth:`recommendations <Spotify.recommendations>` (:issue:`229`)
 
 3.4.0 (2020-11-24)
 ------------------

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -5,9 +5,9 @@ Release notes
 =============
 Unreleased
 ----------
-Changed
-*******
-- :ref:`client` - Update docstring for :func:`Spotify.recommendations`
+Fixed
+*****
+- :ref:`client` - Update documentation for :func:`Spotify.recommendations`
   (:issue:`229`)
 
 3.4.0 (2020-11-24)

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -3,6 +3,13 @@
 
 Release notes
 =============
+Unreleased
+----------
+Changed
+*******
+- :ref:`client` - Update docstring for :func:`Spotify.recommendations`
+  (:issue:`229`)
+
 3.4.0 (2020-11-24)
 ------------------
 Added

--- a/tekore/_client/api/browse/__init__.py
+++ b/tekore/_client/api/browse/__init__.py
@@ -197,11 +197,9 @@ class SpotifyBrowse(SpotifyBase):
         """
         Get a list of recommended tracks for seeds.
 
-        Up to 5 seed values may be provided as artists, genres and tracks.
-
         .. warning::
-            At least one of artist_ids, genres or track_ids must be
-            defined, otherwise Spotify returns an "invalid request" error.
+            The total number of seeds provided in ``artist_ids``, ``genres``
+            and ``track_ids`` must be at least 1 and at most 5.
 
         Parameters
         ----------

--- a/tekore/_client/api/browse/__init__.py
+++ b/tekore/_client/api/browse/__init__.py
@@ -199,6 +199,10 @@ class SpotifyBrowse(SpotifyBase):
 
         Up to 5 seed values may be provided as artists, genres and tracks.
 
+        .. warning::
+            At least one of artist_ids, genres or track_ids must be
+            defined, otherwise Spotify returns an "invalid request" error.
+
         Parameters
         ----------
         artist_ids

--- a/tests/client/browse.py
+++ b/tests/client/browse.py
@@ -1,4 +1,6 @@
 import pytest
+import tekore as tk
+
 from ._resources import artist_ids, category_id, genres, track_id
 
 
@@ -65,6 +67,10 @@ class TestSpotifyArtist:
             market=None
         )
         assert len(rec.tracks) > 0
+
+    def test_recommendations_no_seeds(self, app_client):
+        with pytest.raises(tk.BadRequest):
+            app_client.recommendations()
 
     def test_recommendations_target_attribute(self, app_client):
         rec = app_client.recommendations(


### PR DESCRIPTION
Just a small docstring change to recommendations(), adding a warning about how the [endpoint](https://developer.spotify.com/documentation/web-api/reference/browse/get-recommendations/) requires at least one of the track_ids, genres or artist_ids parameters to be defined.

- [x] Tests written with 100% coverage
- [x] Documentation and changelog entry written
- [x] All `tox` checks passed with an appropriately configured
  [environment](https://github.com/felix-hilden/tekore#running-tests)
