### PR TITLE
Add streaming and app-remote-control scopes

### DIFF
--- a/docs/src/reference/auth.rst
+++ b/docs/src/reference/auth.rst
@@ -56,6 +56,9 @@ to retrieve tokens with additional privileges.
     scope = tk.scope.user_read_email + tk.scope.user_read_private
     token = tk.prompt_for_user_token(*cred, scope)
 
+See Spotify's `Authorization scopes
+<https://developer.spotify.com/documentation/general/guides/scopes/>`_
+guide for scope descriptions.
 Scopes that are required or optional are listed
 in each endpoint's documentation, see :ref:`client`.
 They can also be determined programmatically.

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -7,8 +7,9 @@ Unreleased
 ----------
 Added
 *****
-- :ref:`auth` - Add :meth:`streaming <scope.streaming>` and
-  :meth:`app-remote-control <scope.app_remote_control>` scopes.
+- :ref:`auth` - Add :attr:`streaming <scope.streaming>` and
+  :attr:`app-remote-control <scope.app_remote_control>`
+  as extra scopes (:issue:`237`)
 
 3.4.2 (2020-12-14)
 ------------------

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -3,6 +3,13 @@
 
 Release notes
 =============
+Unreleased
+----------
+Added
+*****
+- :ref:`auth` - Add :meth:`streaming <scope.streaming>` and
+  :meth:`app-remote-control <scope.app_remote_control>` scopes.
+
 3.4.2 (2020-12-14)
 ------------------
 Fixed

--- a/tekore/_auth/scope.py
+++ b/tekore/_auth/scope.py
@@ -20,6 +20,11 @@ class scope(Enum):
         tk.scope.write: Scope = ...           # All write scopes
         tk.scope.every: Scope = read + write  # All available scopes
 
+    .. note::
+
+        :attr:`app_remote_control` and :attr:`streaming` are only used outside
+        of the Web API, and are not included in the premade scope combinations.
+
     Addition and subtraction from both sides is supported
     but delegated to :class:`Scope` and always returns a :class:`Scope`.
     """

--- a/tekore/_auth/scope.py
+++ b/tekore/_auth/scope.py
@@ -44,11 +44,10 @@ class scope(Enum):
     playlist_read_private = 'playlist-read-private'
     playlist_modify_private = 'playlist-modify-private'
 
-    app_remote_control = "app-remote-control"
-
-    streaming = "streaming"
-
     ugc_image_upload = 'ugc-image-upload'
+
+    app_remote_control = 'app-remote-control'
+    streaming = 'streaming'
 
     def __str__(self):
         """Enum value."""

--- a/tekore/_auth/scope.py
+++ b/tekore/_auth/scope.py
@@ -44,6 +44,10 @@ class scope(Enum):
     playlist_read_private = 'playlist-read-private'
     playlist_modify_private = 'playlist-modify-private'
 
+    app_remote_control = "app-remote-control"
+
+    streaming = "streaming"
+
     ugc_image_upload = 'ugc-image-upload'
 
     def __str__(self):


### PR DESCRIPTION
Adds `tekore.scope.streaming` and `tekore.scope.app_remote_control` attributes. 

I didn't include them in `tekore.scope.write`, since I'm unsure if Spotify will let you complete the authorization process if you use an account without Premium.

- [x] Tests written with 100% coverage
- [x] Documentation and changelog entry written
- [x] All `tox` checks passed with an appropriately configured
  [environment](https://github.com/felix-hilden/tekore#running-tests)
