### PR TITLE
Typing improvements

### DIFF
--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -11,6 +11,10 @@ Added
   :attr:`app-remote-control <scope.app_remote_control>`
   as extra scopes (:issue:`237`)
 
+Fixed
+*****
+- :ref:`client` - fix type hints for context managers (:issue:`239`)
+
 3.4.2 (2020-12-14)
 ------------------
 Fixed

--- a/tekore/_client/full.py
+++ b/tekore/_client/full.py
@@ -1,3 +1,4 @@
+from typing import Generator
 from contextlib import contextmanager
 
 from .paging import SpotifyPaging
@@ -65,7 +66,7 @@ class Spotify(
     """
 
     @contextmanager
-    def token_as(self, token) -> 'Spotify':
+    def token_as(self, token) -> Generator['Spotify', None, None]:
         """
         Use a different token with requests. Context manager.
 
@@ -76,8 +77,8 @@ class Spotify(
 
         Returns
         -------
-        Spotify
-            self
+        Generator[Spotify, None, None]
+            self as context
 
         Examples
         --------
@@ -96,7 +97,7 @@ class Spotify(
         self.token = old
 
     @contextmanager
-    def max_limits(self, on: bool = True) -> 'Spotify':
+    def max_limits(self, on: bool = True) -> Generator['Spotify', None, None]:
         """
         Toggle using maximum limits in paging calls. Context manager.
 
@@ -107,8 +108,8 @@ class Spotify(
 
         Returns
         -------
-        Spotify
-            self
+        Generator[Spotify, None, None]
+            self as context
 
         Examples
         --------
@@ -127,7 +128,7 @@ class Spotify(
         self.max_limits_on = old
 
     @contextmanager
-    def chunked(self, on: bool = True) -> 'Spotify':
+    def chunked(self, on: bool = True) -> Generator['Spotify', None, None]:
         """
         Toggle chunking lists of resources. Context manager.
 
@@ -138,8 +139,8 @@ class Spotify(
 
         Returns
         -------
-        Spotify
-            self
+        Generator[Spotify, None, None]
+            self as context
 
         Examples
         --------

--- a/tekore/_model/paging.py
+++ b/tekore/_model/paging.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Sequence
 from dataclasses import dataclass
 
 from .serialise import Model
@@ -9,7 +9,7 @@ class Paging(Model):
     """Paging base."""
 
     href: str
-    items: List[Model]
+    items: Sequence[Model]
     limit: int
     next: str
 


### PR DESCRIPTION
Related issue: #221

This PR improves our type hints a bit once more, fixing some low-hanging fruit in Mypy errors.

- [x] Tests written with 100% coverage
- [x] Documentation and changelog entry written
- [ ] All `tox` checks passed with an appropriately configured
  [environment](https://github.com/felix-hilden/tekore#running-tests)
