### PR TITLE
Make context managers async safe (#242)

### DIFF
--- a/docs/src/advanced_usage.rst
+++ b/docs/src/advanced_usage.rst
@@ -176,10 +176,16 @@ Synchronous credentials clients are recommended.
 
 .. note::
 
-    :ref:`client` context managers are async safe, meaning that they can be used
-    in many tasks without affecting the state of other tasks.
+    :ref:`client` context managers are async safe on Python 3.7+, meaning that
+    they can be used in many tasks without affecting the state of other tasks.
     *However*, setting values outside of all contexts modifies the persistent
     value directly, and as such may affect other tasks.
+
+.. warning::
+
+    :ref:`client` context managers are **not** async safe on Python 3.6
+    due to missing async implementation in the PyPI backport of
+    the ``contextvars`` package from the standard library of Python 3.7.
 
 Localisation
 ------------

--- a/docs/src/advanced_usage.rst
+++ b/docs/src/advanced_usage.rst
@@ -174,6 +174,13 @@ While asynchronous :class:`Credentials` is supported, it is worth considering
 that concurrently refreshing tokens may lead to multiple refreshes for one token.
 Synchronous credentials clients are recommended.
 
+.. note::
+
+    :ref:`client` context managers are async safe, meaning that they can be used
+    in many tasks without affecting the state of other tasks.
+    *However*, setting values outside of all contexts modifies the persistent
+    value directly, and as such may affect other tasks.
+
 Localisation
 ------------
 Many API calls that retrieve track information accept a ``market`` or

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -7,7 +7,8 @@ Unreleased
 ----------
 Added
 *****
-- :ref:`client` - make context managers async safe (:issue:`242`)
+- :ref:`client` - make context managers async safe, adds a dependency to
+  the ``contextvars`` backport for Python 3.6 (:issue:`242`)
 
 3.5.1 (2021-02-12)
 ------------------

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -7,8 +7,9 @@ Unreleased
 ----------
 Added
 *****
-- :ref:`client` - make context managers async safe, adds a dependency to
-  the ``contextvars`` backport for Python 3.6 (:issue:`242`)
+- :ref:`client` - make context managers async safe on Python 3.7+,
+  adds a dependency to the ``contextvars`` backport for Python 3.6
+  (:issue:`242`)
 
 3.5.1 (2021-02-12)
 ------------------

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -3,6 +3,12 @@
 
 Release notes
 =============
+Unreleased
+----------
+Added
+*****
+- :ref:`client` - make context managers async safe (:issue:`242`)
+
 3.5.1 (2021-02-12)
 ------------------
 Fixed

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,8 @@ setuptools.setup(
     python_requires='>=' + python_requires_str,
     install_requires=[
         'httpx>=0.11,<0.17',
-        'dataclasses;python_version<"3.7"'
+        'dataclasses;python_version<"3.7"',
+        'contextvars;python_version<"3.7"',
     ],
     extras_require=extras_require,
 

--- a/tekore/_client/full.py
+++ b/tekore/_client/full.py
@@ -68,7 +68,7 @@ class Spotify(
     @contextmanager
     def token_as(self, token) -> Generator['Spotify', None, None]:
         """
-        Use a different token with requests. Context manager.
+        Use a different token with requests. Context manager, async safe.
 
         Parameters
         ----------
@@ -92,14 +92,14 @@ class Spotify(
             with spotify.token_as(user_token):
                 user = spotify.current_user()
         """
-        self.token, old = token, self.token
+        cv_token = self._token_cv.set(token)
         yield self
-        self.token = old
+        self._token_cv.reset(cv_token)
 
     @contextmanager
     def max_limits(self, on: bool = True) -> Generator['Spotify', None, None]:
         """
-        Toggle using maximum limits in paging calls. Context manager.
+        Toggle using maximum limits in paging calls. Context manager, async safe.
 
         Parameters
         ----------
@@ -123,14 +123,14 @@ class Spotify(
             with spotify.max_limits(False):
                 tracks, = spotify.search('piano')
         """
-        self.max_limits_on, old = on, self.max_limits_on
+        cv_token = self._max_limits_on_cv.set(on)
         yield self
-        self.max_limits_on = old
+        self._max_limits_on_cv.reset(cv_token)
 
     @contextmanager
     def chunked(self, on: bool = True) -> Generator['Spotify', None, None]:
         """
-        Toggle chunking lists of resources. Context manager.
+        Toggle chunking lists of resources. Context manager, async safe.
 
         Parameters
         ----------
@@ -154,6 +154,6 @@ class Spotify(
             with spotify.chunked(False):
                 tracks = spotify.search(many_ids[:50])
         """
-        self.chunked_on, old = on, self.chunked_on
+        cv_token = self._chunked_on_cv.set(on)
         yield self
-        self.chunked_on = old
+        self._chunked_on_cv.reset(cv_token)

--- a/tests/client/full.py
+++ b/tests/client/full.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 import pytest
 from inspect import getmembers, ismethod
 from unittest.mock import MagicMock
@@ -15,6 +16,12 @@ def client():
 
 async def sleep(k):
     return await asyncio.sleep(k * 0.01)
+
+
+contextvars_fail_reason = (
+    'Missing async implementation in'
+    'contextvars backport for Python 3.6!'
+)
 
 
 class TestSpotifyUnits:
@@ -87,6 +94,7 @@ class TestSpotifyUnits:
             client.chunked_on = True
         assert client.chunked_on is False
 
+    @pytest.mark.xfail(sys.version_info < (3, 7), reason=contextvars_fail_reason)
     @pytest.mark.asyncio
     async def test_token_async_interrupt_preserves_context(self, client):
         async def do_a():
@@ -114,6 +122,7 @@ class TestSpotifyUnits:
 
         await asyncio.gather(do_a(), do_b())
 
+    @pytest.mark.xfail(sys.version_info < (3, 7), reason=contextvars_fail_reason)
     @pytest.mark.asyncio
     async def test_token_context_unaffected_by_set_in_another_task(self, client):
         async def do_a():


### PR DESCRIPTION
Related issue: #242

- [x] Tests written with 100% coverage
- [x] Documentation and changelog entry written
- [x] All `tox` checks passed with an appropriately configured
  [environment](https://github.com/felix-hilden/tekore#running-tests)
