### PR TITLE
Fixed typo in recommendations documentation

### DIFF
--- a/tekore/_client/api/browse/__init__.py
+++ b/tekore/_client/api/browse/__init__.py
@@ -208,7 +208,7 @@ class SpotifyBrowse(SpotifyBase):
         genres
             list of seed genre names
         track_ids
-            list of seed artist IDs
+            list of seed track IDs
         limit
             the number of items to return (1..100)
         market


### PR DESCRIPTION
This library is fantastic, I've been using it in my web application. Reading through the docs I came across this small typo. Hopefully I can contribute more significantly in the future.

- [x] Tests written with 100% coverage
- [x] Documentation and changelog entry written
- [x] All `tox` checks passed with an appropriately configured
  [environment](https://github.com/felix-hilden/tekore#running-tests)
