### PR TITLE
Ignore MissingConfigurationWarnings in tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,9 @@ ignore = B305,E402,E501,E722,F401
 [pytest]
 python_files = *.py
 testpaths = tests
-filterwarnings = error
+filterwarnings =
+    error
+    ignore::tekore.MissingConfigurationWarning
 
 [coverage:run]
 source = tekore


### PR DESCRIPTION
Related issue: #247

- [x] Tests written with 100% coverage
- [x] Documentation and changelog entry written
- [x] All `tox` checks passed with an appropriately configured
  [environment](https://github.com/felix-hilden/tekore#running-tests)
