### PR TITLE
Update StrEnum to be case insensitive

### DIFF
--- a/src/tekore/_model/serialise.py
+++ b/src/tekore/_model/serialise.py
@@ -8,6 +8,7 @@ from warnings import warn
 
 
 class StrEnumMeta(EnumMeta):
+    """Metaclass for StrEnum that provides case insensitive get. This does not change values."""
 
     def __new__(metacls, cls, bases, classdict, **kwds):
         enum_class = super().__new__(metacls, cls, bases, classdict, **kwds)
@@ -22,7 +23,7 @@ class StrEnumMeta(EnumMeta):
 
 
 class StrEnum(str, Enum, metaclass=StrEnumMeta):
-    """Convert enumeration members to strings using their name."""
+    """Convert enumeration members to strings using their name and ignore case when getting items. This does not change values."""
 
     def __str__(self):
         return self.name

--- a/src/tekore/_model/serialise.py
+++ b/src/tekore/_model/serialise.py
@@ -1,13 +1,27 @@
 import json
 from dataclasses import asdict, dataclass, fields
 from datetime import datetime
-from enum import Enum
+from enum import Enum, EnumMeta
 from pprint import pprint
 from typing import List, TypeVar, Union
 from warnings import warn
 
 
-class StrEnum(str, Enum):
+class StrEnumMeta(EnumMeta):
+
+    def __new__(metacls, cls, bases, classdict, **kwds):
+        enum_class = super().__new__(metacls, cls, bases, classdict, **kwds)
+        # Make all keys lowercase
+        for k, v in enum_class._member_map_.items():
+            enum_class._member_map_[k] = v.lower()
+        return enum_class
+
+    def __getitem__(self, name: str):
+        # Ignore case on get item
+        return super().__getitem__(name.lower())
+
+
+class StrEnum(str, Enum, metaclass=StrEnumMeta):
     """Convert enumeration members to strings using their name."""
 
     def __str__(self):

--- a/src/tekore/_model/serialise.py
+++ b/src/tekore/_model/serialise.py
@@ -13,8 +13,10 @@ class StrEnumMeta(EnumMeta):
     def __new__(metacls, cls, bases, classdict, **kwds):
         enum_class = super().__new__(metacls, cls, bases, classdict, **kwds)
         # Make all keys lowercase
-        for k, v in enum_class._member_map_.items():
-            enum_class._member_map_[k] = v.lower()
+        copied_member_map = dict(enum_class._member_map_)
+        enum_class._member_map_.clear()
+        for k, v in copied_member_map.items():
+            enum_class._member_map_[k.lower()] = v
         return enum_class
 
     def __getitem__(self, name: str):

--- a/tests/model.py
+++ b/tests/model.py
@@ -22,6 +22,44 @@ class E(StrEnum):
     c = "c"
 
 
+class ECaps(StrEnum):
+    a = "A"
+    b = "B"
+    c = "C"
+
+
+class TestEnumCaseInsensitive:
+    def test_all_caps(self):
+        assert E["A"] == E.a
+        assert E["B"] == E.b
+        assert E["C"] == E.c
+
+    def test_all_lowercase(self):
+        assert E["a"] is E.a
+        assert E["b"] is E.b
+        assert E["c"] is E.c
+
+    def test_in_caps(self):
+        assert ECaps.a in ECaps
+        assert ECaps.b in ECaps
+        assert ECaps.c in ECaps
+
+    def test_all_caps_caps_keys(self):
+        assert ECaps["A"] == ECaps.a
+        assert ECaps["B"] == ECaps.b
+        assert ECaps["C"] == ECaps.c
+
+    def test_all_lowercase_caps_keys(self):
+        assert ECaps["a"] is ECaps.a
+        assert ECaps["b"] is ECaps.b
+        assert ECaps["c"] is ECaps.c
+
+    def test_non_destructive_iter(self):
+        # Should not change caps when iterating or accessing values in other means
+        for e in ECaps:
+            assert e.upper() == e
+
+
 class TestSerialisableEnum:
     def test_enum_repr_shows_enum(self):
         assert "E.a" in repr(E.a)


### PR DESCRIPTION
Spotify recently changed their enums to be all caps in some cases. I found them specifically in `album_type` it's `ALBUM` instead of `album`, which breaks tekore in some cases. tekore broke because it assumed that these keys were a specific case. 

The change I've implemented makes it so that when creating the tekore models, finding the AlbumType and other StrEnum objects is case insensitive. This will help future proof in case Spotify does something similar again in the future. My implementation does not modify values of the enums, just how they are stored and later indexed. If a different solution is desired, let me know.

- [x] Tests written with 100% coverage
- [x] Documentation and changelog entry written
- [x] All `tox` checks passed with an appropriately configured
  [environment](https://github.com/felix-hilden/tekore#running-tests)
