### PR TITLE
Nullable Episode.audio_preview_url

### DIFF
--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -11,7 +11,7 @@ Fixed
   :class:`Audiobook <model.Audiobook>` (:issue:`302`)
 - Changed the type the of ``audio_preview_url`` attribute in the ``Episode`` base 
   class to a nullable string, complying with the `API Documentation 
-  <https://developer.spotify.com/documentation/web-api/reference/get-a-show>`_
+  <https://developer.spotify.com/documentation/web-api/reference/get-an-episode>`_
 
 5.1.1 (2023-10-14)
 ------------------

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -9,6 +9,9 @@ Fixed
 *****
 - Add undocumented ``is_externally_hosted`` attribute to
   :class:`Audiobook <model.Audiobook>` (:issue:`302`)
+- Changed the type the of ``audio_preview_url`` attribute in the ``Episode`` base 
+  class to a nullable string, complying with the `API Documentation 
+  <https://developer.spotify.com/documentation/web-api/reference/get-a-show>`_
 
 5.1.1 (2023-10-14)
 ------------------

--- a/src/tekore/_model/episode.py
+++ b/src/tekore/_model/episode.py
@@ -11,7 +11,7 @@ from .show import SimpleShow
 class Episode(Item):
     """Episode base."""
 
-    audio_preview_url: str
+    audio_preview_url: Optional[str]
     description: str
     duration_ms: int
     explicit: bool


### PR DESCRIPTION
pydantic throws a `ValidationError` when an episode with the `audio_preview_url` field set to none is returned by the Spotify API. That is because the `Episode` base class currently expects `str` instead of `Optional[str]` for this attribute.

The [Spotify API documentation](https://developer.spotify.com/documentation/web-api/reference/get-an-episode) declares the field as a nullable string.

I successfully tested the change using the following minimal example. 
I'm not sure whether or not it would be appropriate to add a check for this change, but I did not create one. It feels wrong to use hard-coded episode IDs in a check since the episodes could change or be taken down in the future...

The existent checks seem to pass just fine, though i've never worked with tox before and might have overlooked something.

```python
import tekore as tk

conf = ('<client_id>', '<client_secret>', 'http://localhost:8080/')
token = tk.prompt_for_user_token(*conf, scope=tk.scope.every)

spotify = tk.Spotify(token)

# works
print(f'with audio_preview_url: {spotify.episode("2VLjHtc7GdVcc2cokEbuI9").name}')

# does not work
print(f'without audio_preview_url: {spotify.episode("1pcBjfGIcXhSuoiBiPazHl").name}')
```

Related issue: I did not create one

- [x] Tests written with 100% coverage
- [ ] Documentation and changelog entry written
- [ ] All `tox` checks passed with an appropriately configured
  [environment](https://github.com/felix-hilden/tekore#running-tests)

PS: This is my first proper pull request, so let me know about anything I can improve :)