### PR TITLE
Fixed a ValidationError when requesting a Playlist without a cover image

### DIFF
--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -3,6 +3,14 @@
 
 Release notes
 =============
+Unreleased
+----------
+Fixed
+*****
+- Changed the type the of the ``images`` attribute in the ``Playlist`` base 
+  class to a nullable list to avoid a ValidationError in cases where the API 
+  returns ``null`` for empty playlists without a custom image.
+
 5.2.1 (2023-11-22)
 ------------------
 Fixed

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -7,7 +7,8 @@ Unreleased
 ----------
 Fixed
 *****
-- Fixed a bug causing a ValidationError when requesting an empty playlist without an image. 
+- Make ``images`` optional in :class:`Playlist <model.Playlist>`
+  to fix getting empty playlists without an image (#309)
 
 5.2.1 (2023-11-22)
 ------------------

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -7,9 +7,7 @@ Unreleased
 ----------
 Fixed
 *****
-- Changed the type the of the ``images`` attribute in the ``Playlist`` base 
-  class to a nullable list to avoid a ValidationError in cases where the API 
-  returns ``null`` for empty playlists without a custom image.
+- Fixed a bug causing a ValidationError when requesting an empty playlist without an image. 
 
 5.2.1 (2023-11-22)
 ------------------

--- a/src/tekore/_model/playlist.py
+++ b/src/tekore/_model/playlist.py
@@ -76,7 +76,7 @@ class Playlist(Item):
     collaborative: bool
     description: Optional[str]
     external_urls: dict
-    images: List[Image]
+    images: Optional[List[Image]]
     name: str
     owner: PublicUser
     public: Optional[bool]


### PR DESCRIPTION
Changed the type the of the `images` attribute in the `Playlist` base class to a nullable list to avoid a pydantic ValidationError in cases where the API returns `null`. This happens when requesting an empty playlist without a custom image.

Related issue: none created

- [x] Tests written with 100% coverage
- [ ] Documentation and changelog entry written

Some tox checks have failed in my environment, though the errors don't seem to be related to the implemented change.

I have manually tested the change by requesting an emtpy playlist using `spotify.playlist('<playlist-id>')`, which resulted in the following (shortened) traceback prior to the change:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for FullPlaylist
images
  Input should be a valid list [type=list_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.3/v/list_type
```