### PR TITLE
Added "ep" to AlbumType enum

### DIFF
--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -3,6 +3,13 @@
 
 Release notes
 =============
+Unreleased
+------------------
+Fixed
+*****
+- Add ``ep`` as a valid enum to :class:`AlbumType <model.AlbumType>`
+  for top tracks API responses (:issue:`318`)
+
 5.3.1 (2024-10-28)
 ------------------
 Fixed

--- a/src/tekore/_model/album/base.py
+++ b/src/tekore/_model/album/base.py
@@ -12,6 +12,7 @@ class AlbumType(StrEnum):
     album = "album"
     compilation = "compilation"
     single = "single"
+    ep = "ep"
 
 
 class Album(Item):


### PR DESCRIPTION
Related issue: #318 

Ran into the same issue and the fix was simple enough. However, I'm unsure on writing a test that'll cover it for any user.  The api seems to only return this album type for top tracks (as of writing). Requesting the track or album specifically just gives the (presumably older/depreciating default) 'single' return type.
