### PR TITLE
Add ugc_image_upload scope to playlist_cover_image_upload

### DIFF
--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -7,6 +7,8 @@ Unreleased
 -----------
 Fixed
 *****
+- Add `ugc_image_upload` to required scopes of
+  :meth:`SpotifyPlaylistModify.playlist_cover_image_upload`
 - Make ``available_markets`` of :class:`Show <model.Show>`,
   :class:`LocalAlbum <model.LocalAlbum>` and
   :class:`LocalTrack <model.LocalTrack>` optional (:issue:`323`)
@@ -51,7 +53,7 @@ Fixed
 
 Added
 *****
-- Add ``restrictions`` to :class:`FullEpisode <model.FullEpisode>` 
+- Add ``restrictions`` to :class:`FullEpisode <model.FullEpisode>`
   (:issue:`310`)
 - Support HTTPX ``0.26`` (:issue:`311`)
 - Improve ``UnknownModelAttributeWarning`` to include model name (:issue:`313`)

--- a/src/tekore/_client/api/playlist/modify.py
+++ b/src/tekore/_client/api/playlist/modify.py
@@ -10,7 +10,10 @@ from ...process import nothing, single
 class SpotifyPlaylistModify(SpotifyBase):
     """Playlist API endpoints for modifying playlists."""
 
-    @scopes([scope.playlist_modify_public], [scope.playlist_modify_private])
+    @scopes(
+        [scope.playlist_modify_public, scope.ugc_image_upload],
+        [scope.playlist_modify_private],
+    )
     @send_and_process(nothing)
     def playlist_cover_image_upload(self, playlist_id: str, image: str) -> None:
         """


### PR DESCRIPTION
Uploading a cover image to a playlist needs the `ugc-image-upload` scope. This change adds this scope to required scopes of `SpotifyPlaylistModify.playlist_cover_image_upload`.

I does not look like this change needs to be covered by a test.

- [-] Tests written with 100% coverage
- [+] Documentation and changelog entry written
- [+] All `tox` checks passed with an appropriately configured
  [environment](https://github.com/felix-hilden/tekore#running-tests)
