### PR TITLE
Add open_browser param to auth prompts

### DIFF
--- a/docs/src/getting_started.rst
+++ b/docs/src/getting_started.rst
@@ -62,6 +62,8 @@ can be used with a client with no other redirect URIs whitelisted.
 Different privileges or `scopes` can be requested when authorising.
 Below we'll retrieve a token that has every possible scope.
 The script will open a web page prompting for a Spotify login.
+To only display the authorization URI, without opening it in a browser,
+set `open_browser` to `False` in `prompt_for_user_token`.
 The user is then redirected back to the whitelisted redirect URI.
 Paste the redirected URI in full to the shell to finalise token retrieval.
 

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -11,6 +11,12 @@ Fixed
   :class:`LocalAlbum <model.LocalAlbum>` and
   :class:`LocalTrack <model.LocalTrack>` optional (:issue:`323`)
 
+Added
+*****
+- Add ``open_browser`` option to
+  :meth:`prompt_for_user_token <prompt_for_user_token>` and
+  :meth:`prompt_for_pkce_token <prompt_for_pkce_token>`
+
 5.4.0 (2024-02-27)
 ------------------
 Fixed

--- a/src/tekore/_auth/util.py
+++ b/src/tekore/_auth/util.py
@@ -198,7 +198,11 @@ def request_client_token(client_id: str, client_secret: str) -> RefreshingToken:
 
 
 def prompt_for_user_token(
-    client_id: str, client_secret: str, redirect_uri: str, scope=None
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+    scope=None,
+    open_browser: bool = True,
 ) -> RefreshingToken:
     """
     Prompt for manual authorisation.
@@ -218,6 +222,8 @@ def prompt_for_user_token(
         token privileges, accepts a :class:`Scope`, a single :class:`scope`,
         a list of :class:`scopes <scope>` and strings for :class:`Scope`,
         or a space-separated list of scopes as a string
+    open_browser
+        open a web browser with auth url, or just print it
 
     Returns
     -------
@@ -232,8 +238,11 @@ def prompt_for_user_token(
     cred = RefreshingCredentials(client_id, client_secret, redirect_uri)
     auth = UserAuth(cred, scope=scope)
 
-    print("Opening browser for Spotify login...")
-    webbrowser.open(auth.url)
+    if open_browser:
+        print("Opening browser for Spotify login...")
+        webbrowser.open(auth.url)
+    else:
+        print("Open this URL in your browser: " + auth.url)
     redirected = input("Please paste redirect URL: ").strip()
     return auth.request_token(url=redirected)
 
@@ -263,7 +272,7 @@ def refresh_user_token(
 
 
 def prompt_for_pkce_token(
-    client_id: str, redirect_uri: str, scope=None
+    client_id: str, redirect_uri: str, scope=None, open_browser: bool = True
 ) -> RefreshingToken:
     """
     Prompt for manual authorisation with PKCE.
@@ -281,6 +290,8 @@ def prompt_for_pkce_token(
         token privileges, accepts a :class:`Scope`, a single :class:`scope`,
         a list of :class:`scopes <scope>` and strings for :class:`Scope`,
         or a space-separated list of scopes as a string
+    open_browser
+        open a web browser with auth url, or just print it
 
     Returns
     -------
@@ -295,8 +306,11 @@ def prompt_for_pkce_token(
     cred = RefreshingCredentials(client_id, redirect_uri=redirect_uri)
     auth = UserAuth(cred, scope=scope, pkce=True)
 
-    print("Opening browser for Spotify login...")
-    webbrowser.open(auth.url)
+    if open_browser:
+        print("Opening browser for Spotify login...")
+        webbrowser.open(auth.url)
+    else:
+        print("Open this URL in your browser: " + auth.url)
     redirected = input("Please paste redirect URL: ").strip()
     return auth.request_token(url=redirected)
 


### PR DESCRIPTION
This PR adds an `open_browser` parameter to both auth prompt functions. This is intended to behave similarly to the option in [spotipy](https://github.com/spotipy-dev/spotipy/blob/8f003147f7649e957223373b2da4deae2bcdec36/spotipy/oauth2.py#L313-L314) ([ref 2](https://github.com/spotipy-dev/spotipy/blob/8f003147f7649e957223373b2da4deae2bcdec36/spotipy/oauth2.py#L431-L440)), allowing for interactive auth without an attempt to open the system default browser.

This beneficial in some instances where opening the default browser could be abrupt to the user; I sometimes find manually pasting the link into my currently open browser helpful, as e.g. my system default browser is not open at the time, or I am using WSL, a VM, a container, etc. from which the relevant auth code is being invoked.

The `open_browser` param has a default value of `True`, so as to not modify the existing default behavior.

Related issue: None

- [x] Tests written with 100% coverage
  - N/A
- [x] Documentation and changelog entry written
- [x] All `tox` checks passed with an appropriately configured
  [environment](https://github.com/felix-hilden/tekore#running-tests)
