### PR TITLE
Allow for missing track preview_url

### DIFF
--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -1,6 +1,12 @@
 .. _release-notes:
 .. currentmodule:: tekore
 
+Unreleased
+----------
+Fixed
+*****
+- Allow for missing ``preview_url`` in :class:`Track <model.Track>`
+
 Release notes
 =============
 5.5.0 (2024-07-04)

--- a/src/tekore/_model/track.py
+++ b/src/tekore/_model/track.py
@@ -28,7 +28,7 @@ class Track(Item):
     is_playable: Optional[bool] = None
     linked_from: Optional[TrackLink] = None
     name: str
-    preview_url: Optional[str]
+    preview_url: Optional[str] = None
     restrictions: Optional[Restrictions] = None
     track_number: int
 


### PR DESCRIPTION
Related issue: N/A

- [x] Tests written with 100% coverage
- [x] Documentation and changelog entry written
- [x] All `tox` checks passed with an appropriately configured
  [environment](https://github.com/felix-hilden/tekore#running-tests)

Apparently unplayable tracks (see https://open.spotify.com/album/72unDeCzOJ7Ho2fICTX8Kz in NL market) don't have `preview_url` attribute set. I'm not sure if this is the case for all unplayable tracks, or just these two, but `Track` needs to have a default for `preview_url` set to `None` to handle this case.