### PR TITLE
Typing fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "readme_pypi.rst"
 license = {file = "LICENSE"}
 dynamic = ["version"]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "httpx>=0.15,<0.28",
     "pydantic>=1.8,!=2.4.0,!=2.5.0,!=2.5.1",
@@ -24,10 +24,11 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Multimedia :: Sound/Audio",
 ]
 

--- a/src/tekore/_auth/expiring/client.py
+++ b/src/tekore/_auth/expiring/client.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 from base64 import b64encode as _b64encode
 from hashlib import sha256
 from secrets import token_urlsafe
-from typing import Tuple
 from urllib.parse import urlencode
 
 from ..._sender import Client, Request, Sender, send_and_process
@@ -46,10 +47,10 @@ class Credentials(Client):
     def __init__(
         self,
         client_id: str,
-        client_secret: str = None,
-        redirect_uri: str = None,
-        sender: Sender = None,
-        asynchronous: bool = None,
+        client_secret: str | None = None,
+        redirect_uri: str | None = None,
+        sender: Sender | None = None,
+        asynchronous: bool | None = None,
     ):
         super().__init__(sender, asynchronous)
         self.client_id = client_id
@@ -106,7 +107,7 @@ class Credentials(Client):
         return payload
 
     def user_authorisation_url(
-        self, scope=None, state: str = None, show_dialog: bool = False
+        self, scope=None, state: str | None = None, show_dialog: bool = False
     ) -> str:
         """
         Construct an authorisation URL.
@@ -180,8 +181,8 @@ class Credentials(Client):
         return self._token_request(payload, auth=True), (refresh_token,)
 
     def pkce_user_authorisation(
-        self, scope=None, state: str = None, verifier_bytes: int = 32
-    ) -> Tuple[str, str]:
+        self, scope = None, state: str | None = None, verifier_bytes: int = 32
+    ) -> tuple[str, str]:
         """
         Construct authorisation URL and verifier.
 
@@ -204,7 +205,7 @@ class Credentials(Client):
 
         Returns
         -------
-        Tuple[str, str]
+        tuple[str, str]
             authorisation URL and PKCE code verifier
         """
         assert 32 <= verifier_bytes <= 96, "Invalid number of verifier bytes!"

--- a/src/tekore/_auth/expiring/decor.py
+++ b/src/tekore/_auth/expiring/decor.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 from ..._sender import Request, Response
 from ..._sender.error import get_error

--- a/src/tekore/_auth/expiring/token.py
+++ b/src/tekore/_auth/expiring/token.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import time
 from abc import ABC, abstractmethod
-from typing import Union
 
 from ..scope import Scope
 
@@ -60,7 +61,7 @@ class Token(AccessToken):
         return self._access_token
 
     @property
-    def refresh_token(self) -> Union[str, None]:
+    def refresh_token(self) -> str | None:
         """
         Refresh token for generating new access tokens.
 

--- a/src/tekore/_auth/refreshing.py
+++ b/src/tekore/_auth/refreshing.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from __future__ import annotations
 
 from .._sender import Sender
 from .expiring import AccessToken, Credentials, Token
@@ -54,7 +54,7 @@ class RefreshingToken(AccessToken):
         return self._token.access_token
 
     @property
-    def refresh_token(self) -> Union[str, None]:
+    def refresh_token(self) -> str | None:
         """
         Refresh token for generating new access tokens.
 
@@ -125,9 +125,9 @@ class RefreshingCredentials:
     def __init__(
         self,
         client_id: str,
-        client_secret: str = None,
-        redirect_uri: str = None,
-        sender: Sender = None,
+        client_secret: str | None = None,
+        redirect_uri: str | None = None,
+        sender: Sender | None = None,
     ):
         self.credentials = Credentials(
             client_id, client_secret, redirect_uri, sender, asynchronous=False
@@ -155,7 +155,7 @@ class RefreshingCredentials:
         return RefreshingToken(token, self.credentials)
 
     def user_authorisation_url(
-        self, scope=None, state: str = None, show_dialog: bool = False
+        self, scope = None, state: str | None = None, show_dialog: bool = False
     ) -> str:
         """
         Construct an authorisation URL.
@@ -221,8 +221,8 @@ class RefreshingCredentials:
         return RefreshingToken(token, self.credentials)
 
     def pkce_user_authorisation(
-        self, scope=None, state: str = None, verifier_bytes: int = 32
-    ) -> Tuple[str, str]:
+        self, scope = None, state: str | None = None, verifier_bytes: int = 32
+    ) -> tuple[str, str]:
         """
         Construct authorisation URL and verifier.
 
@@ -245,7 +245,7 @@ class RefreshingCredentials:
 
         Returns
         -------
-        Tuple[str, str]
+        tuple[str, str]
             authorisation URL and PKCE code verifier
         """
         return self.credentials.pkce_user_authorisation(scope, state, verifier_bytes)

--- a/src/tekore/_auth/util.py
+++ b/src/tekore/_auth/util.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import webbrowser
 from secrets import token_urlsafe
-from typing import Union
 from urllib.parse import parse_qs, urlparse
 
 from .expiring import Credentials, Token
@@ -112,7 +113,7 @@ class UserAuth:
 
     def __init__(
         self,
-        cred: Union[Credentials, RefreshingCredentials],
+        cred: Credentials | RefreshingCredentials,
         scope=None,
         pkce: bool = False,
     ):
@@ -138,8 +139,8 @@ class UserAuth:
         return type(self).__name__ + "(" + ", ".join(options) + ")"
 
     def request_token(
-        self, code: str = None, state: str = None, url: str = None
-    ) -> Union[Token, RefreshingToken]:
+        self, code: str | None = None, state: str | None = None, url: str | None = None
+    ) -> Token | RefreshingToken:
         """
         Verify state consistency and request token.
 
@@ -154,7 +155,7 @@ class UserAuth:
 
         Returns
         -------
-        Union[Token, RefreshingToken]
+        Token | RefreshingToken
             access token
 
         Raises
@@ -201,7 +202,7 @@ def prompt_for_user_token(
     client_id: str,
     client_secret: str,
     redirect_uri: str,
-    scope=None,
+    scope = None,
     open_browser: bool = True,
 ) -> RefreshingToken:
     """
@@ -272,7 +273,7 @@ def refresh_user_token(
 
 
 def prompt_for_pkce_token(
-    client_id: str, redirect_uri: str, scope=None, open_browser: bool = True
+    client_id: str, redirect_uri: str, scope = None, open_browser: bool = True
 ) -> RefreshingToken:
     """
     Prompt for manual authorisation with PKCE.

--- a/src/tekore/_client/api/album.py
+++ b/src/tekore/_client/api/album.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 from tekore.model import FullAlbum, SimpleTrackPaging
 
@@ -13,7 +13,7 @@ class SpotifyAlbum(SpotifyBase):
 
     @scopes()
     @send_and_process(single(FullAlbum))
-    def album(self, album_id: str, market: str = None) -> FullAlbum:
+    def album(self, album_id: str, market: str | None = None) -> FullAlbum:
         """
         Get an album.
 
@@ -30,7 +30,7 @@ class SpotifyAlbum(SpotifyBase):
     @send_and_process(single(SimpleTrackPaging))
     @maximise_limit(50)
     def album_tracks(
-        self, album_id: str, market: str = None, limit: int = 20, offset: int = 0
+        self, album_id: str, market: str | None = None, limit: int = 20, offset: int = 0
     ) -> SimpleTrackPaging:
         """
         Get tracks on album.
@@ -53,7 +53,7 @@ class SpotifyAlbum(SpotifyBase):
     @scopes()
     @chunked("album_ids", 1, 20, join_lists)
     @send_and_process(model_list(FullAlbum, "albums"))
-    def albums(self, album_ids: list, market: str = None) -> List[FullAlbum]:
+    def albums(self, album_ids: list, market: str | None = None) -> list[FullAlbum]:
         """
         Get multiple albums.
 

--- a/src/tekore/_client/api/artist.py
+++ b/src/tekore/_client/api/artist.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from __future__ import annotations
 
 from tekore.model import AlbumGroup, FullArtist, FullTrack, SimpleAlbumPaging
 
@@ -27,7 +27,7 @@ class SpotifyArtist(SpotifyBase):
     @scopes()
     @chunked("artist_ids", 1, 50, join_lists)
     @send_and_process(model_list(FullArtist, "artists"))
-    def artists(self, artist_ids: list) -> List[FullArtist]:
+    def artists(self, artist_ids: list) -> list[FullArtist]:
         """
         Get information for multiple artists.
 
@@ -44,8 +44,8 @@ class SpotifyArtist(SpotifyBase):
     def artist_albums(
         self,
         artist_id: str,
-        include_groups: List[Union[str, AlbumGroup]] = None,
-        market: str = None,
+        include_groups: list[str | AlbumGroup] | None = None,
+        market: str | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> SimpleAlbumPaging:
@@ -77,7 +77,7 @@ class SpotifyArtist(SpotifyBase):
 
     @scopes()
     @send_and_process(model_list(FullTrack, "tracks"))
-    def artist_top_tracks(self, artist_id: str, market: str) -> List[FullTrack]:
+    def artist_top_tracks(self, artist_id: str, market: str) -> list[FullTrack]:
         """
         Get an artist's top 10 tracks by country.
 
@@ -92,7 +92,7 @@ class SpotifyArtist(SpotifyBase):
 
     @scopes()
     @send_and_process(model_list(FullArtist, "artists"))
-    def artist_related_artists(self, artist_id: str) -> List[FullArtist]:
+    def artist_related_artists(self, artist_id: str) -> list[FullArtist]:
         """
         Get artists similar to an identified artist.
 

--- a/src/tekore/_client/api/audiobook.py
+++ b/src/tekore/_client/api/audiobook.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 from tekore.model import FullAudiobook, SimpleChapterPaging
 
@@ -13,7 +13,7 @@ class SpotifyAudiobook(SpotifyBase):
 
     @scopes()
     @send_and_process(single(FullAudiobook))
-    def audiobook(self, audiobook_id: str, market: str = None) -> FullAudiobook:
+    def audiobook(self, audiobook_id: str, market: str | None = None) -> FullAudiobook:
         """
         Get information for an audiobook.
 
@@ -34,8 +34,8 @@ class SpotifyAudiobook(SpotifyBase):
     @chunked("audiobook_ids", 1, 50, join_lists)
     @send_and_process(model_list(FullAudiobook, "audiobooks"))
     def audiobooks(
-        self, audiobook_ids: list, market: str = None
-    ) -> List[FullAudiobook]:
+        self, audiobook_ids: list, market: str | None = None
+    ) -> list[FullAudiobook]:
         """
         Get information for multiple audiobooks.
 
@@ -56,7 +56,7 @@ class SpotifyAudiobook(SpotifyBase):
     @send_and_process(single(SimpleChapterPaging))
     @maximise_limit(50)
     def audiobook_chapters(
-        self, audiobook_id: str, market: str = None, limit: int = 20, offset: int = 0
+        self, audiobook_id: str, market: str | None = None, limit: int = 20, offset: int = 0
     ) -> SimpleChapterPaging:
         """
         Get chapters of an audiobook.

--- a/src/tekore/_client/api/browse/__init__.py
+++ b/src/tekore/_client/api/browse/__init__.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from __future__ import annotations
 
 from tekore.model import (
     Category,
@@ -26,12 +26,12 @@ class SpotifyBrowse(SpotifyBase):
     @maximise_limit(50)
     def featured_playlists(
         self,
-        country: str = None,
-        locale: str = None,
-        timestamp: str = None,
+        country: str | None = None,
+        locale: str | None = None,
+        timestamp: str | None = None,
         limit: int = 20,
         offset: int = 0,
-    ) -> Tuple[str, SimplePlaylistPaging]:
+    ) -> tuple[str, SimplePlaylistPaging]:
         """
         Get a list of Spotify featured playlists.
 
@@ -53,7 +53,7 @@ class SpotifyBrowse(SpotifyBase):
 
         Returns
         -------
-        Tuple[str, SimplePlaylistPaging]
+        tuple[str, SimplePlaylistPaging]
             message and playlists
         """
         return self._get(
@@ -69,7 +69,7 @@ class SpotifyBrowse(SpotifyBase):
     @send_and_process(single(SimpleAlbumPaging, from_item="albums"))
     @maximise_limit(50)
     def new_releases(
-        self, country: str = None, limit: int = 20, offset: int = 0
+        self, country: str | None = None, limit: int = 20, offset: int = 0
     ) -> SimpleAlbumPaging:
         """
         Get a list of new album releases featured in Spotify.
@@ -91,7 +91,7 @@ class SpotifyBrowse(SpotifyBase):
     @send_and_process(single(CategoryPaging, from_item="categories"))
     @maximise_limit(50)
     def categories(
-        self, country: str = None, locale: str = None, limit: int = 20, offset: int = 0
+        self, country: str | None = None, locale: str | None = None, limit: int = 20, offset: int = 0
     ) -> CategoryPaging:
         """
         Get a list of categories used to tag items in Spotify.
@@ -119,7 +119,7 @@ class SpotifyBrowse(SpotifyBase):
     @scopes()
     @send_and_process(single(Category))
     def category(
-        self, category_id: str, country: str = None, locale: str = None
+        self, category_id: str, country: str | None = None, locale: str | None = None
     ) -> Category:
         """
         Get a single category used to tag items in Spotify.
@@ -142,7 +142,7 @@ class SpotifyBrowse(SpotifyBase):
     @send_and_process(single(SimplePlaylistPaging, from_item="playlists"))
     @maximise_limit(50)
     def category_playlists(
-        self, category_id: str, country: str = None, limit: int = 20, offset: int = 0
+        self, category_id: str, country: str | None = None, limit: int = 20, offset: int = 0
     ) -> SimplePlaylistPaging:
         """
         Get a list of Spotify playlists tagged with a particular category.
@@ -170,11 +170,11 @@ class SpotifyBrowse(SpotifyBase):
     @maximise_limit(100)
     def recommendations(
         self,
-        artist_ids: list = None,
-        genres: list = None,
-        track_ids: list = None,
+        artist_ids: list | None = None,
+        genres: list | None = None,
+        track_ids: list | None = None,
         limit: int = 20,
-        market: str = None,
+        market: str | None = None,
         **attributes,
     ) -> Recommendations:
         """
@@ -223,6 +223,6 @@ class SpotifyBrowse(SpotifyBase):
 
     @scopes()
     @send_and_process(top_item("genres"))
-    def recommendation_genre_seeds(self) -> List[str]:
+    def recommendation_genre_seeds(self) -> list[str]:
         """Get a list of available genre seeds."""
         return self._get("recommendations/available-genre-seeds")

--- a/src/tekore/_client/api/chapter.py
+++ b/src/tekore/_client/api/chapter.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 from tekore.model import FullChapter
 
@@ -13,7 +13,7 @@ class SpotifyChapter(SpotifyBase):
 
     @scopes()
     @send_and_process(single(FullChapter))
-    def chapter(self, chapter_id: str, market: str = None) -> FullChapter:
+    def chapter(self, chapter_id: str, market: str | None = None) -> FullChapter:
         """
         Get information for a chapter.
 
@@ -33,7 +33,7 @@ class SpotifyChapter(SpotifyBase):
     @scopes()
     @chunked("chapter_ids", 1, 50, join_lists)
     @send_and_process(model_list(FullChapter, "chapters"))
-    def chapters(self, chapter_ids: list, market: str = None) -> List[FullChapter]:
+    def chapters(self, chapter_ids: list, market: str | None = None) -> list[FullChapter]:
         """
         Get information for multiple chapters.
 

--- a/src/tekore/_client/api/episode.py
+++ b/src/tekore/_client/api/episode.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 from tekore.model import FullEpisode
 
@@ -13,7 +13,7 @@ class SpotifyEpisode(SpotifyBase):
 
     @scopes()
     @send_and_process(single(FullEpisode))
-    def episode(self, episode_id: str, market: str = None) -> FullEpisode:
+    def episode(self, episode_id: str, market: str | None = None) -> FullEpisode:
         """
         Get information for an episode.
 
@@ -33,7 +33,7 @@ class SpotifyEpisode(SpotifyBase):
     @scopes()
     @chunked("episode_ids", 1, 50, join_lists)
     @send_and_process(model_list(FullEpisode, "episodes"))
-    def episodes(self, episode_ids: list, market: str = None) -> List[FullEpisode]:
+    def episodes(self, episode_ids: list, market: str | None = None) -> list[FullEpisode]:
         """
         Get information for multiple episodes.
 

--- a/src/tekore/_client/api/follow.py
+++ b/src/tekore/_client/api/follow.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 from tekore._auth import scope
 from tekore.model import FullArtistCursorPaging
@@ -15,7 +15,7 @@ class SpotifyFollow(SpotifyBase):
     @scopes(optional=[scope.playlist_read_private])
     @chunked("user_ids", 2, 5, join_lists)
     @send_and_process(nothing)
-    def playlist_is_following(self, playlist_id: str, user_ids: list) -> List[bool]:
+    def playlist_is_following(self, playlist_id: str, user_ids: list) -> list[bool]:
         """
         Check if users are following a playlist.
 
@@ -28,7 +28,7 @@ class SpotifyFollow(SpotifyBase):
 
         Returns
         -------
-        List[bool]
+        list[bool]
             follow statuses in the same order that the user IDs were given
         """
         return self._get(
@@ -68,7 +68,7 @@ class SpotifyFollow(SpotifyBase):
     @send_and_process(single(FullArtistCursorPaging, from_item="artists"))
     @maximise_limit(50)
     def followed_artists(
-        self, limit: int = 20, after: str = None
+        self, limit: int = 20, after: str | None = None
     ) -> FullArtistCursorPaging:
         """
         Get artists followed by the current user.
@@ -85,7 +85,7 @@ class SpotifyFollow(SpotifyBase):
     @scopes([scope.user_follow_read])
     @chunked("artist_ids", 1, 50, join_lists)
     @send_and_process(nothing)
-    def artists_is_following(self, artist_ids: list) -> List[bool]:
+    def artists_is_following(self, artist_ids: list) -> list[bool]:
         """
         Check if current user follows artists.
 
@@ -96,7 +96,7 @@ class SpotifyFollow(SpotifyBase):
 
         Returns
         -------
-        List[bool]
+        list[bool]
             follow statuses in the same order that the artist IDs were given
         """
         return self._get(
@@ -134,7 +134,7 @@ class SpotifyFollow(SpotifyBase):
     @scopes([scope.user_follow_read])
     @chunked("user_ids", 1, 50, join_lists)
     @send_and_process(nothing)
-    def users_is_following(self, user_ids: list) -> List[bool]:
+    def users_is_following(self, user_ids: list) -> list[bool]:
         """
         Check if current user follows users.
 
@@ -145,7 +145,7 @@ class SpotifyFollow(SpotifyBase):
 
         Returns
         -------
-        List[bool]
+        list[bool]
             follow statuses in the same order that the user IDs were given
         """
         return self._get("me/following/contains", type="user", ids=",".join(user_ids))

--- a/src/tekore/_client/api/library.py
+++ b/src/tekore/_client/api/library.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 from tekore._auth import scope
 from tekore.model import (
@@ -21,7 +21,7 @@ class SpotifyLibrary(SpotifyBase):
     @send_and_process(single(SavedAlbumPaging))
     @maximise_limit(50)
     def saved_albums(
-        self, market: str = None, limit: int = 20, offset: int = 0
+        self, market: str | None = None, limit: int = 20, offset: int = 0
     ) -> SavedAlbumPaging:
         """
         Get the albums saved in the current user's library.
@@ -40,7 +40,7 @@ class SpotifyLibrary(SpotifyBase):
     @scopes([scope.user_library_read])
     @chunked("album_ids", 1, 50, join_lists)
     @send_and_process(nothing)
-    def saved_albums_contains(self, album_ids: list) -> List[bool]:
+    def saved_albums_contains(self, album_ids: list[str]) -> list[bool]:
         """
         Check if user has saved albums.
 
@@ -51,7 +51,7 @@ class SpotifyLibrary(SpotifyBase):
 
         Returns
         -------
-        List[bool]
+        list[bool]
             save statuses in the same order the album IDs were given
         """
         return self._get("me/albums/contains?ids=" + ",".join(album_ids))
@@ -59,7 +59,7 @@ class SpotifyLibrary(SpotifyBase):
     @scopes([scope.user_library_modify])
     @chunked("album_ids", 1, 50, return_none)
     @send_and_process(nothing)
-    def saved_albums_add(self, album_ids: list) -> None:
+    def saved_albums_add(self, album_ids: list[str]) -> None:
         """
         Save albums for current user.
 
@@ -73,7 +73,7 @@ class SpotifyLibrary(SpotifyBase):
     @scopes([scope.user_library_modify])
     @chunked("album_ids", 1, 50, return_none)
     @send_and_process(nothing)
-    def saved_albums_delete(self, album_ids: list) -> None:
+    def saved_albums_delete(self, album_ids: list[str]) -> None:
         """
         Remove albums for current user.
 
@@ -88,7 +88,7 @@ class SpotifyLibrary(SpotifyBase):
     @send_and_process(single(SavedEpisodePaging))
     @maximise_limit(50)
     def saved_episodes(
-        self, market: str = None, limit: int = 20, offset: int = 0
+        self, market: str | None = None, limit: int = 20, offset: int = 0
     ) -> SavedEpisodePaging:
         """
         Get the episodes saved in the current user's library.
@@ -107,7 +107,7 @@ class SpotifyLibrary(SpotifyBase):
     @scopes([scope.user_library_read])
     @chunked("episode_ids", 1, 50, join_lists)
     @send_and_process(nothing)
-    def saved_episodes_contains(self, episode_ids: list) -> List[bool]:
+    def saved_episodes_contains(self, episode_ids: list) -> list[bool]:
         """
         Check if user has saved episodes.
 
@@ -118,7 +118,7 @@ class SpotifyLibrary(SpotifyBase):
 
         Returns
         -------
-        List[bool]
+        list[bool]
             save statuses in the same order the episode IDs were given
         """
         return self._get("me/episodes/contains?ids=" + ",".join(episode_ids))
@@ -155,7 +155,7 @@ class SpotifyLibrary(SpotifyBase):
     @send_and_process(single(SavedTrackPaging))
     @maximise_limit(50)
     def saved_tracks(
-        self, market: str = None, limit: int = 20, offset: int = 0
+        self, market: str | None = None, limit: int = 20, offset: int = 0
     ) -> SavedTrackPaging:
         """
         Get the songs saved in the current user's library.
@@ -174,7 +174,7 @@ class SpotifyLibrary(SpotifyBase):
     @scopes([scope.user_library_read])
     @chunked("track_ids", 1, 50, join_lists)
     @send_and_process(nothing)
-    def saved_tracks_contains(self, track_ids: list) -> List[bool]:
+    def saved_tracks_contains(self, track_ids: list) -> list[bool]:
         """
         Check if user has saved tracks.
 
@@ -185,7 +185,7 @@ class SpotifyLibrary(SpotifyBase):
 
         Returns
         -------
-        List[bool]
+        list[bool]
             save statuses in the same order the track IDs were given
         """
         return self._get("me/tracks/contains?ids=" + ",".join(track_ids))
@@ -222,7 +222,7 @@ class SpotifyLibrary(SpotifyBase):
     @send_and_process(single(SavedShowPaging))
     @maximise_limit(50)
     def saved_shows(
-        self, market: str = None, limit: int = 20, offset: int = 0
+        self, market: str | None = None, limit: int = 20, offset: int = 0
     ) -> SavedShowPaging:
         """
         Get the shows saved in the current user's library.
@@ -241,7 +241,7 @@ class SpotifyLibrary(SpotifyBase):
     @scopes([scope.user_library_read])
     @chunked("show_ids", 1, 50, join_lists)
     @send_and_process(nothing)
-    def saved_shows_contains(self, show_ids: list) -> List[bool]:
+    def saved_shows_contains(self, show_ids: list) -> list[bool]:
         """
         Check if user has saved shows.
 
@@ -252,7 +252,7 @@ class SpotifyLibrary(SpotifyBase):
 
         Returns
         -------
-        List[bool]
+        list[bool]
             save statuses in the same order the show IDs were given
         """
         return self._get("me/shows/contains?ids=" + ",".join(show_ids))
@@ -274,7 +274,7 @@ class SpotifyLibrary(SpotifyBase):
     @scopes([scope.user_library_modify])
     @chunked("show_ids", 1, 50, return_none)
     @send_and_process(nothing)
-    def saved_shows_delete(self, show_ids: list, market: str = None) -> None:
+    def saved_shows_delete(self, show_ids: list, market: str | None = None) -> None:
         """
         Remove shows for current user.
 

--- a/src/tekore/_client/api/markets.py
+++ b/src/tekore/_client/api/markets.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from ..base import SpotifyBase
 from ..decor import scopes, send_and_process
 from ..process import top_item
@@ -10,13 +8,13 @@ class SpotifyMarkets(SpotifyBase):
 
     @scopes()
     @send_and_process(top_item("markets"))
-    def markets(self) -> List[str]:
+    def markets(self) -> list[str]:
         """
         Get available market country codes.
 
         Returns
         -------
-        List[str]
+        list[str]
             available markets
         """
         return self._get("markets")

--- a/src/tekore/_client/api/player/modify.py
+++ b/src/tekore/_client/api/player/modify.py
@@ -1,4 +1,4 @@
-from typing import Union
+from __future__ import annotations
 
 from tekore._auth import scope
 from tekore._convert import to_uri
@@ -9,7 +9,7 @@ from ...decor import scopes, send_and_process
 from ...process import nothing
 
 
-def offset_to_dict(offset: Union[int, str]):
+def offset_to_dict(offset: int | str):
     """
     Parse playback start offset to an appropriate payload member.
 
@@ -43,7 +43,7 @@ class SpotifyPlayerModify(SpotifyBase):
 
     @scopes([scope.user_modify_playback_state])
     @send_and_process(nothing)
-    def playback_resume(self, device_id: str = None) -> None:
+    def playback_resume(self, device_id: str | None = None) -> None:
         """
         Resume user's playback.
 
@@ -59,9 +59,9 @@ class SpotifyPlayerModify(SpotifyBase):
     def playback_start_tracks(
         self,
         track_ids: list,
-        offset: Union[int, str] = None,
-        position_ms: int = None,
-        device_id: str = None,
+        offset: int | str | None = None,
+        position_ms: int | None = None,
+        device_id: str | None = None,
     ) -> None:
         """
         Start playback of one or more tracks.
@@ -90,9 +90,9 @@ class SpotifyPlayerModify(SpotifyBase):
     def playback_start_context(
         self,
         context_uri: str,
-        offset: Union[int, str] = None,
-        position_ms: int = None,
-        device_id: str = None,
+        offset: int | str | None = None,
+        position_ms: int | None = None,
+        device_id: str | None = None,
     ) -> None:
         """
         Start playback of a context: an album, artist or playlist.
@@ -119,7 +119,7 @@ class SpotifyPlayerModify(SpotifyBase):
 
     @scopes([scope.user_modify_playback_state])
     @send_and_process(nothing)
-    def playback_queue_add(self, uri: str, device_id: str = None) -> None:
+    def playback_queue_add(self, uri: str, device_id: str | None = None) -> None:
         """
         Add a track or an episode to a user's queue.
 
@@ -134,7 +134,7 @@ class SpotifyPlayerModify(SpotifyBase):
 
     @scopes([scope.user_modify_playback_state])
     @send_and_process(nothing)
-    def playback_pause(self, device_id: str = None) -> None:
+    def playback_pause(self, device_id: str | None = None) -> None:
         """
         Pause a user's playback.
 
@@ -147,7 +147,7 @@ class SpotifyPlayerModify(SpotifyBase):
 
     @scopes([scope.user_modify_playback_state])
     @send_and_process(nothing)
-    def playback_next(self, device_id: str = None) -> None:
+    def playback_next(self, device_id: str | None = None) -> None:
         """
         Skip user's playback to next track.
 
@@ -160,7 +160,7 @@ class SpotifyPlayerModify(SpotifyBase):
 
     @scopes([scope.user_modify_playback_state])
     @send_and_process(nothing)
-    def playback_previous(self, device_id: str = None) -> None:
+    def playback_previous(self, device_id: str | None = None) -> None:
         """
         Skip user's playback to previous track.
 
@@ -173,7 +173,7 @@ class SpotifyPlayerModify(SpotifyBase):
 
     @scopes([scope.user_modify_playback_state])
     @send_and_process(nothing)
-    def playback_seek(self, position_ms: int, device_id: str = None) -> None:
+    def playback_seek(self, position_ms: int, device_id: str | None = None) -> None:
         """
         Seek to position in current playing track.
 
@@ -189,7 +189,7 @@ class SpotifyPlayerModify(SpotifyBase):
     @scopes([scope.user_modify_playback_state])
     @send_and_process(nothing)
     def playback_repeat(
-        self, state: Union[str, RepeatState], device_id: str = None
+        self, state: str | RepeatState, device_id: str | None = None
     ) -> None:
         """
         Set repeat mode for playback.
@@ -205,7 +205,7 @@ class SpotifyPlayerModify(SpotifyBase):
 
     @scopes([scope.user_modify_playback_state])
     @send_and_process(nothing)
-    def playback_shuffle(self, state: bool, device_id: str = None) -> None:
+    def playback_shuffle(self, state: bool, device_id: str | None = None) -> None:
         """
         Toggle shuffle for user's playback.
 
@@ -221,7 +221,7 @@ class SpotifyPlayerModify(SpotifyBase):
 
     @scopes([scope.user_modify_playback_state])
     @send_and_process(nothing)
-    def playback_volume(self, volume_percent: int, device_id: str = None) -> None:
+    def playback_volume(self, volume_percent: int, device_id: str | None = None) -> None:
         """
         Set volume for user's playback.
 

--- a/src/tekore/_client/api/player/view.py
+++ b/src/tekore/_client/api/player/view.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 from tekore._auth import scope
 from tekore.model import (
@@ -20,7 +20,7 @@ class SpotifyPlayerView(SpotifyBase):
     @scopes([scope.user_read_playback_state])
     @send_and_process(single(CurrentlyPlayingContext))
     def playback(
-        self, market: str = None, tracks_only: bool = False
+        self, market: str | None = None, tracks_only: bool = False
     ) -> CurrentlyPlayingContext:
         """
         Get information about user's current playback.
@@ -51,7 +51,7 @@ class SpotifyPlayerView(SpotifyBase):
     )
     @send_and_process(single(CurrentlyPlaying))
     def playback_currently_playing(
-        self, market: str = None, tracks_only: bool = False
+        self, market: str | None = None, tracks_only: bool = False
     ) -> CurrentlyPlaying:
         """
         Get user's currently playing track.
@@ -86,7 +86,7 @@ class SpotifyPlayerView(SpotifyBase):
     @send_and_process(single(PlayHistoryPaging))
     @maximise_limit(50)
     def playback_recently_played(
-        self, limit: int = 20, after: int = None, before: int = None
+        self, limit: int = 20, after: int | None = None, before: int | None = None
     ) -> PlayHistoryPaging:
         """
         Get tracks from the current user's recently played tracks.
@@ -108,7 +108,7 @@ class SpotifyPlayerView(SpotifyBase):
 
     @scopes([scope.user_read_playback_state])
     @send_and_process(model_list(Device, "devices"))
-    def playback_devices(self) -> List[Device]:
+    def playback_devices(self) -> list[Device]:
         """Get a user's available devices."""
         return self._get("me/player/devices")
 

--- a/src/tekore/_client/api/playlist/view.py
+++ b/src/tekore/_client/api/playlist/view.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from functools import wraps
-from typing import Callable, Iterable, List, Union
+from collections.abc import Callable, Iterable
 
 from tekore._auth import scope
 from tekore.model import FullPlaylist, Image, PlaylistTrackPaging, SimplePlaylistPaging
@@ -109,10 +111,10 @@ class SpotifyPlaylistView(SpotifyBase):
     def playlist(
         self,
         playlist_id: str,
-        fields: str = None,
-        market: str = None,
-        as_tracks: Union[bool, Iterable[str]] = False,
-    ) -> Union[FullPlaylist, dict]:
+        fields: str | None = None,
+        market: str | None = None,
+        as_tracks: bool | Iterable[str] = False,
+    ) -> FullPlaylist | dict:
         """
         Get playlist of a user.
 
@@ -139,7 +141,7 @@ class SpotifyPlaylistView(SpotifyBase):
 
         Returns
         -------
-        Union[FullPlaylist, dict]
+        FullPlaylist | dict
             playlist object, or raw dictionary if ``fields``
             or ``as_tracks`` was specified
         """
@@ -153,7 +155,7 @@ class SpotifyPlaylistView(SpotifyBase):
 
     @scopes()
     @send_and_process(model_list(Image))
-    def playlist_cover_image(self, playlist_id: str) -> List[Image]:
+    def playlist_cover_image(self, playlist_id: str) -> list[Image]:
         """
         Get cover image of a playlist.
 
@@ -174,12 +176,12 @@ class SpotifyPlaylistView(SpotifyBase):
     def playlist_items(
         self,
         playlist_id: str,
-        fields: str = None,
-        market: str = None,
-        as_tracks: Union[bool, Iterable[str]] = False,
+        fields: str | None = None,
+        market: str | None = None,
+        as_tracks: bool | Iterable[str] = False,
         limit: int = 100,
         offset: int = 0,
-    ) -> Union[PlaylistTrackPaging, dict]:
+    ) -> PlaylistTrackPaging | dict:
         """
         Full details of items on a playlist.
 
@@ -210,7 +212,7 @@ class SpotifyPlaylistView(SpotifyBase):
 
         Returns
         -------
-        Union[PlaylistTrackPaging, dict]
+        PlaylistTrackPaging | dict
             paging object containing playlist items, or raw dictionary
             if ``fields`` or ``as_tracks`` was specified
         """

--- a/src/tekore/_client/api/show.py
+++ b/src/tekore/_client/api/show.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 from tekore._auth import scope
 from tekore.model import FullShow, SimpleEpisodePaging
@@ -14,7 +14,7 @@ class SpotifyShow(SpotifyBase):
 
     @scopes(optional=[scope.user_read_playback_position])
     @send_and_process(single(FullShow))
-    def show(self, show_id: str, market: str = None) -> FullShow:
+    def show(self, show_id: str, market: str | None = None) -> FullShow:
         """
         Get information for a show.
 
@@ -37,7 +37,7 @@ class SpotifyShow(SpotifyBase):
     @scopes(optional=[scope.user_read_playback_position])
     @chunked("show_ids", 1, 50, join_lists)
     @send_and_process(model_list(FullShow, "shows"))
-    def shows(self, show_ids: list, market: str = None) -> List[FullShow]:
+    def shows(self, show_ids: list, market: str | None = None) -> list[FullShow]:
         """
         Get information for multiple shows.
 
@@ -61,7 +61,7 @@ class SpotifyShow(SpotifyBase):
     @send_and_process(single(SimpleEpisodePaging))
     @maximise_limit(50)
     def show_episodes(
-        self, show_id: str, market: str = None, limit: int = 20, offset: int = 0
+        self, show_id: str, market: str | None = None, limit: int = 20, offset: int = 0
     ) -> SimpleEpisodePaging:
         """
         Get episodes of a show.

--- a/src/tekore/_client/api/track.py
+++ b/src/tekore/_client/api/track.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 from tekore.model import AudioAnalysis, AudioFeatures, FullTrack
 
@@ -29,7 +29,7 @@ class SpotifyTrack(SpotifyBase):
     @scopes()
     @chunked("track_ids", 1, 50, join_lists)
     @send_and_process(model_list(FullTrack, "tracks"))
-    def tracks(self, track_ids: list, market: str = None) -> List[FullTrack]:
+    def tracks(self, track_ids: list, market: str | None = None) -> list[FullTrack]:
         """
         Get information for multiple tracks.
 
@@ -62,7 +62,7 @@ class SpotifyTrack(SpotifyBase):
     @scopes()
     @chunked("track_ids", 1, 100, join_lists)
     @send_and_process(model_list(AudioFeatures, "audio_features"))
-    def tracks_audio_features(self, track_ids: list) -> List[AudioFeatures]:
+    def tracks_audio_features(self, track_ids: list) -> list[AudioFeatures]:
         """
         Get audio feature information for multiple tracks.
 

--- a/src/tekore/_client/base.py
+++ b/src/tekore/_client/base.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from contextvars import ContextVar
-from typing import Coroutine, Optional, Union
+from collections.abc import Coroutine
 
 from tekore._sender import Client, Request, Response, Sender
 
@@ -13,7 +15,7 @@ def build_url(url: str) -> str:
     return url
 
 
-def parse_url_params(params: Optional[dict]) -> Optional[dict]:
+def parse_url_params(params: dict | None) -> dict | None:
     """Generate parameter dict and filter Nones."""
     params = params or {}
     return {k: v for k, v in params.items() if v is not None} or None
@@ -28,9 +30,9 @@ class SpotifyBase(Client):
 
     def __init__(
         self,
-        token=None,
-        sender: Sender = None,
-        asynchronous: bool = None,
+        token = None,
+        sender: Sender | None = None,
+        asynchronous: bool | None = None,
         max_limits_on: bool = False,
         chunked_on: bool = False,
     ):
@@ -98,8 +100,7 @@ class SpotifyBase(Client):
         }
 
     def send(
-        self, request: Request
-    ) -> Union[Response, Coroutine[None, None, Response]]:
+        self, request: Request) -> Response | Coroutine[None, None, Response]:
         """
         Build request url and headers, and send with underlying sender.
 
@@ -116,7 +117,7 @@ class SpotifyBase(Client):
         return self.sender.send(request)
 
     @staticmethod
-    def _request(method: str, url: str, payload: dict = None, params: dict = None):
+    def _request(method: str, url: str, payload: dict | None = None, params: dict | None = None):
         return (
             Request(
                 method=method, url=url, params=parse_url_params(params), json=payload
@@ -124,14 +125,14 @@ class SpotifyBase(Client):
             (),
         )
 
-    def _get(self, url: str, payload: dict = None, **params):
+    def _get(self, url: str, payload: dict | None = None, **params):
         return self._request("GET", url, payload=payload, params=params)
 
-    def _post(self, url: str, payload: dict = None, **params):
+    def _post(self, url: str, payload: dict | None = None, **params):
         return self._request("POST", url, payload=payload, params=params)
 
-    def _delete(self, url: str, payload: dict = None, **params):
+    def _delete(self, url: str, payload: dict | None = None, **params):
         return self._request("DELETE", url, payload=payload, params=params)
 
-    def _put(self, url: str, payload: dict = None, **params):
+    def _put(self, url: str, payload: dict | None = None, **params):
         return self._request("PUT", url, payload=payload, params=params)

--- a/src/tekore/_client/chunked.py
+++ b/src/tekore/_client/chunked.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
+from collections.abc import Callable
 from functools import wraps
-from typing import Callable
 
 
 def _chunks(lst: list, n: int, reverse: bool) -> list:
@@ -42,10 +44,10 @@ def chunked(
     arg_pos: int,
     chunk_size: int,
     process: Callable,
-    reverse: str = None,
-    reverse_pos: int = None,
-    chain: str = None,
-    chain_pos: int = None,
+    reverse: str | None = None,
+    reverse_pos: int | None = None,
+    chain: str | None = None,
+    chain_pos: int | None = None,
 ) -> Callable:
     """
     Decorate a function to make multiple calls splitting a list argument.

--- a/src/tekore/_client/decor/__init__.py
+++ b/src/tekore/_client/decor/__init__.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
+from collections.abc import Callable
 from functools import wraps
-from typing import Callable
 
 from tekore._auth import Scope
 from tekore._sender import send_and_process as _send_and_process
@@ -66,7 +68,7 @@ def _add_doc_section(doc: str, section: str) -> str:
     return "\n".join([empty, head, "", section, body])
 
 
-def scopes(required: list = None, optional: list = None) -> Callable:
+def scopes(required: list | None = None, optional: list | None = None) -> Callable:
     """
     List the scopes that a call uses.
 

--- a/src/tekore/_client/full.py
+++ b/src/tekore/_client/full.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import Generator
+from collections.abc import Generator
 
 from .api import (
     SpotifyAlbum,

--- a/src/tekore/_client/paging.py
+++ b/src/tekore/_client/paging.py
@@ -1,5 +1,6 @@
-from typing import Generator, Optional
+from __future__ import annotations
 
+from collections.abc import Generator
 from tekore._sender import BadRequest
 from tekore.model import Model, OffsetPaging, Paging
 
@@ -24,7 +25,7 @@ class SpotifyPaging(SpotifyBase):
     def _get_paging_result(self, address: str):
         return self._get(address)
 
-    def next(self, page: Paging) -> Optional[Paging]:
+    def next(self, page: Paging) -> Paging | None:
         """
         Retrieve the next result set of a paging object.
 
@@ -50,7 +51,7 @@ class SpotifyPaging(SpotifyBase):
         except BadRequest:
             return
 
-    async def _async_next(self, page: Paging) -> Optional[Paging]:
+    async def _async_next(self, page: Paging) -> Paging | None:
         if page.next is None:
             return
 
@@ -60,7 +61,7 @@ class SpotifyPaging(SpotifyBase):
         except BadRequest:
             return
 
-    def previous(self, page: OffsetPaging) -> Optional[OffsetPaging]:
+    def previous(self, page: OffsetPaging) -> OffsetPaging | None:
         """
         Retrieve the previous result set of a paging object.
 
@@ -83,7 +84,7 @@ class SpotifyPaging(SpotifyBase):
         previous_set = self._get_paging_result(page.previous)
         return type(page)(**previous_set)
 
-    async def _async_previous(self, page: OffsetPaging) -> Optional[OffsetPaging]:
+    async def _async_previous(self, page: OffsetPaging) -> OffsetPaging | None:
         if page.previous is None:
             return
 

--- a/src/tekore/_client/process.py
+++ b/src/tekore/_client/process.py
@@ -1,4 +1,6 @@
-from typing import Callable
+from __future__ import annotations
+
+from collections.abc import Callable
 
 from tekore.model import Model
 
@@ -17,7 +19,7 @@ def top_item(item: str) -> Callable:
     return post_func
 
 
-def single(type_: Model, from_item: str = None) -> Callable:
+def single(type_: Model, from_item: str | None = None) -> Callable:
     """
     Unpack dict or items in ``from_item`` into single constructor.
 
@@ -31,7 +33,7 @@ def single(type_: Model, from_item: str = None) -> Callable:
     return post_func
 
 
-def model_list(type_: Model, from_item: str = None) -> Callable:
+def model_list(type_: Model, from_item: str | None = None) -> Callable:
     """Unpack items inside ``from_item`` of dict into constructors."""
 
     def post_func(json: dict):

--- a/src/tekore/_config.py
+++ b/src/tekore/_config.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
 from configparser import ConfigParser
 from os import environ
-from typing import Iterable, Union
 from warnings import warn
 
 
@@ -148,7 +150,7 @@ def config_from_file(
 
 
 def config_to_file(
-    file_path: str, values: Union[Iterable, dict], section: str = "DEFAULT"
+    file_path: str, values: Iterable | dict, section: str = "DEFAULT"
 ) -> None:
     """
     Write configuration to a config file.

--- a/src/tekore/_convert.py
+++ b/src/tekore/_convert.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import re
-from typing import Tuple, Union
 
 from tekore.model import StrEnum
 
@@ -20,7 +21,7 @@ class IdentifierType(StrEnum):
     user = "user"
 
 
-def check_type(type_: Union[str, IdentifierType]) -> None:
+def check_type(type_: str | IdentifierType) -> None:
     """
     Validate type of an ID.
 
@@ -52,7 +53,7 @@ def check_id(id_: str) -> None:
         raise ConversionError(f"Invalid id: {id_!r}!")
 
 
-def to_uri(type_: Union[str, IdentifierType], id_: str) -> str:
+def to_uri(type_: str | IdentifierType, id_: str) -> str:
     """
     Convert an ID to an URI of the appropriate type.
 
@@ -79,7 +80,7 @@ def to_uri(type_: Union[str, IdentifierType], id_: str) -> str:
     return f"spotify:{type_}:{id_}"
 
 
-def to_url(type_: Union[str, IdentifierType], id_: str) -> str:
+def to_url(type_: str | IdentifierType, id_: str) -> str:
     """
     Convert an ID to an URL of the appropriate type.
 
@@ -108,7 +109,7 @@ def to_url(type_: Union[str, IdentifierType], id_: str) -> str:
     return f"https://open.spotify.com/{type_}/{id_}"
 
 
-def from_uri(uri: str) -> Tuple[str, str]:
+def from_uri(uri: str) -> tuple[str, str]:
     """
     Parse type and ID from an URI.
 
@@ -119,7 +120,7 @@ def from_uri(uri: str) -> Tuple[str, str]:
 
     Returns
     -------
-    Tuple[str, str]
+    tuple[str, str]
         type and ID parsed from the URI
 
     Raises
@@ -149,7 +150,7 @@ _url_prefixes = (
 )
 
 
-def from_url(url: str) -> Tuple[str, str]:
+def from_url(url: str) -> tuple[str, str]:
     """
     Parse type and ID from an URL.
 
@@ -162,7 +163,7 @@ def from_url(url: str) -> Tuple[str, str]:
 
     Returns
     -------
-    Tuple[str, str]
+    tuple[str, str]
         type and ID parsed from the URL
 
     Raises

--- a/src/tekore/_model/album/__init__.py
+++ b/src/tekore/_model/album/__init__.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from __future__ import annotations
 
 from ..album.base import Album, AlbumType
 from ..paging import OffsetPaging
@@ -25,10 +25,10 @@ class SimpleAlbum(Album):
     and it appears to only be ``True`` when it is present.
     """
 
-    album_group: Optional[AlbumGroup] = None
+    album_group: AlbumGroup | None = None
 
 
 class SimpleAlbumPaging(OffsetPaging):
     """Paging containing simplified albums."""
 
-    items: List[SimpleAlbum]
+    items: list[SimpleAlbum]

--- a/src/tekore/_model/album/base.py
+++ b/src/tekore/_model/album/base.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from __future__ import annotations
 
 from ..artist import SimpleArtist
 from ..base import Item
@@ -19,12 +19,12 @@ class Album(Item):
     """Album base."""
 
     album_type: AlbumType
-    artists: List[SimpleArtist]
+    artists: list[SimpleArtist]
     external_urls: dict
-    images: List[Image]
+    images: list[Image]
     name: str
     total_tracks: int
     release_date: str
     release_date_precision: ReleaseDatePrecision
-    available_markets: Optional[List[str]] = None
-    is_playable: Optional[bool] = None
+    available_markets: list[str] | None = None
+    is_playable: bool | None = None

--- a/src/tekore/_model/album/full.py
+++ b/src/tekore/_model/album/full.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import datetime
-from typing import List, Optional
 
 from ..album.base import Album
 from ..member import Copyright
@@ -18,10 +19,10 @@ class FullAlbum(Album):
     and it appears to only be ``True`` when it is present.
     """
 
-    copyrights: List[Copyright]
+    copyrights: list[Copyright]
     external_ids: dict
-    genres: List[str]
-    label: Optional[str]
+    genres: list[str]
+    label: str | None
     popularity: int
     tracks: SimpleTrackPaging
 
@@ -36,4 +37,4 @@ class SavedAlbum(Model):
 class SavedAlbumPaging(OffsetPaging):
     """Paging of albums in library."""
 
-    items: List[SavedAlbum]
+    items: list[SavedAlbum]

--- a/src/tekore/_model/artist.py
+++ b/src/tekore/_model/artist.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from .base import Item
 from .member import Followers, Image
 from .paging import CursorPaging, OffsetPaging
@@ -20,19 +18,19 @@ class FullArtist(Artist):
     """Complete artist object."""
 
     followers: Followers
-    genres: List[str]
-    images: List[Image]
+    genres: list[str]
+    images: list[Image]
     popularity: int
 
 
 class FullArtistCursorPaging(CursorPaging):
     """Paging of full artists."""
 
-    items: List[FullArtist]
+    items: list[FullArtist]
     total: int
 
 
 class FullArtistOffsetPaging(OffsetPaging):
     """Paging of full artists."""
 
-    items: List[FullArtist]
+    items: list[FullArtist]

--- a/src/tekore/_model/audio_analysis.py
+++ b/src/tekore/_model/audio_analysis.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from __future__ import annotations
 
 from .serialise import Model
 
@@ -11,8 +11,8 @@ class TimeInterval(Model):
     """
 
     duration: float
-    start: Optional[float] = None
-    confidence: Optional[float] = None
+    start: float | None = None
+    confidence: float | None = None
 
 
 class Section(Model):
@@ -30,10 +30,10 @@ class Section(Model):
     mode_confidence: float
     time_signature: int
     time_signature_confidence: float
-    confidence: Optional[float] = None
-    mode: Optional[int] = None
-    key: Optional[int] = None
-    start: Optional[float] = None
+    confidence: float | None = None
+    mode: int | None = None
+    key: int | None = None
+    start: float | None = None
 
 
 class Segment(Model):
@@ -46,12 +46,12 @@ class Segment(Model):
     duration: float
     loudness_start: float
     loudness_max: float
-    pitches: List[float]
-    timbre: List[float]
-    confidence: Optional[float] = None
-    loudness_end: Optional[float] = None
-    loudness_max_time: Optional[float] = None
-    start: Optional[float] = None
+    pitches: list[float]
+    timbre: list[float]
+    confidence: float | None = None
+    loudness_end: float | None = None
+    loudness_max_time: float | None = None
+    start: float | None = None
 
 
 class AudioAnalysis(Model):
@@ -64,10 +64,10 @@ class AudioAnalysis(Model):
     for more details.
     """
 
-    bars: List[TimeInterval]
-    beats: List[TimeInterval]
-    sections: List[Section]
-    segments: List[Segment]
-    tatums: List[TimeInterval]
+    bars: list[TimeInterval]
+    beats: list[TimeInterval]
+    sections: list[Section]
+    segments: list[Segment]
+    tatums: list[TimeInterval]
     meta: dict
     track: dict

--- a/src/tekore/_model/audiobook/__init__.py
+++ b/src/tekore/_model/audiobook/__init__.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from __future__ import annotations
 
 from ..paging import OffsetPaging
 from .base import Audiobook, Author, Narrator
@@ -11,10 +11,10 @@ class SimpleAudiobook(Audiobook):
     May contain :attr:`chapters`, but that is likely an error.
     """
 
-    chapters: Optional[dict] = None
+    chapters: dict | None = None
 
 
 class SimpleAudiobookPaging(OffsetPaging):
     """Paging of simplified audiobooks."""
 
-    items: List[SimpleAudiobook]
+    items: list[SimpleAudiobook]

--- a/src/tekore/_model/audiobook/base.py
+++ b/src/tekore/_model/audiobook/base.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from __future__ import annotations
 
 from ..base import Item
 from ..member import Copyright, Image
@@ -20,19 +20,19 @@ class Narrator(Model):
 class Audiobook(Item):
     """Audiobook base."""
 
-    authors: List[Author]
-    available_markets: Optional[List[str]] = None
-    copyrights: List[Copyright]
+    authors: list[Author]
+    available_markets: list[str] | None = None
+    copyrights: list[Copyright]
     description: str
-    edition: Optional[str]
+    edition: str | None
     explicit: bool
     external_urls: dict
     html_description: str
-    images: List[Image]
-    is_externally_hosted: Optional[bool] = None
-    languages: List[str]
+    images: list[Image]
+    is_externally_hosted: bool | None = None
+    languages: list[str]
     media_type: str
     name: str
-    narrators: List[Narrator]
+    narrators: list[Narrator]
     publisher: str
-    total_chapters: Optional[int]
+    total_chapters: int | None

--- a/src/tekore/_model/audiobook/full.py
+++ b/src/tekore/_model/audiobook/full.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from ..chapter import SimpleChapterPaging
 from .base import Audiobook
@@ -8,4 +8,4 @@ class FullAudiobook(Audiobook):
     """Complete audiobook object."""
 
     chapters: SimpleChapterPaging
-    is_playable: Optional[bool] = None
+    is_playable: bool | None = None

--- a/src/tekore/_model/category.py
+++ b/src/tekore/_model/category.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from .base import Identifiable
 from .member import Image
 from .paging import OffsetPaging
@@ -9,11 +7,11 @@ class Category(Identifiable):
     """Spotify tag category."""
 
     href: str
-    icons: List[Image]
+    icons: list[Image]
     name: str
 
 
 class CategoryPaging(OffsetPaging):
     """Paging of categories."""
 
-    items: List[Category]
+    items: list[Category]

--- a/src/tekore/_model/chapter/__init__.py
+++ b/src/tekore/_model/chapter/__init__.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from ..paging import OffsetPaging
 from .base import Chapter
 
@@ -11,4 +9,4 @@ class SimpleChapter(Chapter):
 class SimpleChapterPaging(OffsetPaging):
     """Paging of simplified chapters."""
 
-    items: List[SimpleChapter]
+    items: list[SimpleChapter]

--- a/src/tekore/_model/chapter/base.py
+++ b/src/tekore/_model/chapter/base.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from __future__ import annotations
 
 from ..base import Item
 from ..member import Image, ReleaseDatePrecision, Restrictions, ResumePoint
@@ -7,19 +7,19 @@ from ..member import Image, ReleaseDatePrecision, Restrictions, ResumePoint
 class Chapter(Item):
     """Audiobook chapter base."""
 
-    audio_preview_url: Optional[str]
-    available_markets: Optional[List[str]] = None
+    audio_preview_url: str | None
+    available_markets: list[str] | None = None
     chapter_number: int
     description: str
     duration_ms: int
     explicit: bool
     external_urls: dict
     html_description: str
-    images: List[Image]
-    is_playable: Optional[bool] = None
-    languages: List[str]
+    images: list[Image]
+    is_playable: bool | None = None
+    languages: list[str]
     name: str
     release_date_precision: ReleaseDatePrecision
     release_date: str
-    restrictions: Optional[Restrictions] = None
-    resume_point: Optional[ResumePoint] = None
+    restrictions: Restrictions | None = None
+    resume_point: ResumePoint | None = None

--- a/src/tekore/_model/currently_playing.py
+++ b/src/tekore/_model/currently_playing.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from __future__ import annotations
 
 from .context import Context
 from .device import Device
@@ -46,7 +46,7 @@ class Actions(Model):
     disallows: Disallows
 
 
-PlaybackItem = Union[FullTrack, LocalTrack, FullEpisode, None]
+PlaybackItem = FullTrack | LocalTrack | FullEpisode | None
 
 
 class CurrentlyPlaying(Model):
@@ -61,8 +61,8 @@ class CurrentlyPlaying(Model):
     currently_playing_type: CurrentlyPlayingType
     is_playing: bool
     timestamp: int
-    context: Optional[Context]
-    progress_ms: Optional[int]
+    context: Context | None
+    progress_ms: int | None
     item: PlaybackItem
 
 
@@ -76,11 +76,11 @@ class CurrentlyPlayingContext(CurrentlyPlaying):
     device: Device
     repeat_state: RepeatState
     shuffle_state: bool
-    smart_shuffle: Optional[bool]
+    smart_shuffle: bool | None
 
 
 class Queue(Model):
     """Playback queue."""
 
     currently_playing: PlaybackItem
-    queue: List[PlaybackItem]
+    queue: list[PlaybackItem]

--- a/src/tekore/_model/device.py
+++ b/src/tekore/_model/device.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from .base import Identifiable
 from .serialise import StrEnum
@@ -30,5 +30,5 @@ class Device(Identifiable):
     is_restricted: bool
     name: str
     type: DeviceType
-    volume_percent: Optional[int]
+    volume_percent: int | None
     supports_volume: bool

--- a/src/tekore/_model/episode.py
+++ b/src/tekore/_model/episode.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import datetime
-from typing import List, Optional
 
 from .base import Item
 from .member import Image, ReleaseDatePrecision, Restrictions, ResumePoint
@@ -15,21 +16,21 @@ class Episode(Item):
     :attr:`language` is deprecated.
     """
 
-    audio_preview_url: Optional[str]
+    audio_preview_url: str | None
     description: str
     duration_ms: int
     explicit: bool
     external_urls: dict
     html_description: str
-    images: List[Image]
+    images: list[Image]
     is_externally_hosted: bool
-    is_playable: Optional[bool] = None
-    language: Optional[str] = None
-    languages: List[str]
+    is_playable: bool | None = None
+    language: str | None = None
+    languages: list[str]
     name: str
     release_date: str
     release_date_precision: ReleaseDatePrecision
-    resume_point: Optional[ResumePoint] = None
+    resume_point: ResumePoint | None = None
 
 
 class SimpleEpisode(Episode):
@@ -39,14 +40,14 @@ class SimpleEpisode(Episode):
 class FullEpisode(Episode):
     """Complete episode object."""
 
-    restrictions: Optional[Restrictions] = None
+    restrictions: Restrictions | None = None
     show: SimpleShow
 
 
 class SimpleEpisodePaging(OffsetPaging):
     """Paging of simplified episodes."""
 
-    items: List[SimpleEpisode]
+    items: list[SimpleEpisode]
 
 
 class SavedEpisode(Model):
@@ -59,4 +60,4 @@ class SavedEpisode(Model):
 class SavedEpisodePaging(OffsetPaging):
     """Paging of episodes in library."""
 
-    items: List[SavedEpisode]
+    items: list[SavedEpisode]

--- a/src/tekore/_model/local.py
+++ b/src/tekore/_model/local.py
@@ -1,4 +1,6 @@
-from typing import List, Literal, Union
+from __future__ import annotations
+
+from typing import Literal
 
 from pydantic import Field
 
@@ -12,17 +14,17 @@ class LocalItem(Model):
     href: None
     name: str
     type: str
-    uri: None
+    uri: str | None
 
 
 class LocalAlbum(LocalItem):
     """Album of a locally saved track."""
 
     album_type: None
-    artists: List[None]
-    available_markets: List[None] = Field(default_factory=list)
+    artists: list[None]
+    available_markets: list[None] = Field(default_factory=list)
     external_urls: dict
-    images: List[None]
+    images: list[None]
     release_date: None
     release_date_precision: None
 
@@ -43,10 +45,10 @@ class LocalTrack(LocalItem):
     """
 
     album: LocalAlbum
-    artists: List[LocalArtist]
-    available_markets: List[None] = Field(default_factory=list)
+    artists: list[LocalArtist]
+    available_markets: list[None] = Field(default_factory=list)
     disc_number: int
-    duration_ms: Union[int, dict]
+    duration_ms: int | dict
     explicit: bool
     external_ids: dict
     external_urls: dict
@@ -54,4 +56,4 @@ class LocalTrack(LocalItem):
     popularity: int
     preview_url: None
     track_number: int
-    uri: str
+    uri: str | None

--- a/src/tekore/_model/member.py
+++ b/src/tekore/_model/member.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from .serialise import Model, StrEnum
 
@@ -39,8 +39,8 @@ class Image(Model):
     """
 
     url: str
-    height: Optional[int]
-    width: Optional[int]
+    height: int | None
+    width: int | None
 
 
 class Restrictions(Model):

--- a/src/tekore/_model/paging.py
+++ b/src/tekore/_model/paging.py
@@ -1,5 +1,5 @@
-from typing import Optional, Sequence
-
+from __future__ import annotations
+from collections.abc import Sequence
 from .serialise import Model
 
 
@@ -9,7 +9,7 @@ class Paging(Model):
     href: str
     items: Sequence[Model]
     limit: int
-    next: Optional[str]
+    next: str | None
 
 
 class OffsetPaging(Paging):
@@ -21,13 +21,13 @@ class OffsetPaging(Paging):
 
     total: int
     offset: int
-    previous: Optional[str]
+    previous: str | None
 
 
 class Cursor(Model):
     """Data cursor."""
 
-    after: Optional[str]
+    after: str | None
 
 
 class CursorPaging(Paging):

--- a/src/tekore/_model/play_history.py
+++ b/src/tekore/_model/play_history.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import datetime
-from typing import List, Optional
 
 from .context import Context
 from .paging import Cursor, CursorPaging
@@ -16,7 +17,7 @@ class PlayHistory(Model):
 
     track: FullTrack
     played_at: datetime
-    context: Optional[Context]
+    context: Context | None
 
 
 class PlayHistoryCursor(Cursor):
@@ -32,5 +33,5 @@ class PlayHistoryPaging(CursorPaging):
     Cursors are not available when paging is exhausted.
     """
 
-    items: List[PlayHistory]
-    cursors: Optional[PlayHistoryCursor]
+    items: list[PlayHistory]
+    cursors: PlayHistoryCursor | None

--- a/src/tekore/_model/playlist.py
+++ b/src/tekore/_model/playlist.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from datetime import datetime
-from typing import List, Literal, Optional, Union
+from typing import Literal
 
 from .base import Item
 from .episode import FullEpisode
@@ -33,7 +35,7 @@ class FullPlaylistEpisode(FullEpisode):
     :attr:`available_markets` is undocumented.
     """
 
-    available_markets: Optional[List[str]] = None
+    available_markets: list[str] | None = None
     episode: Literal[True]
     track: Literal[False]
 
@@ -56,16 +58,16 @@ class PlaylistTrack(Model):
     added_at: datetime
     added_by: PublicUser
     is_local: bool
-    track: Union[FullPlaylistTrack, FullPlaylistEpisode, LocalPlaylistTrack, None]
+    track: FullPlaylistTrack | FullPlaylistEpisode | LocalPlaylistTrack | None
 
-    primary_color: Optional[str]
-    video_thumbnail: Optional[dict]
+    primary_color: str | None
+    video_thumbnail: dict | None
 
 
 class PlaylistTrackPaging(OffsetPaging):
     """Paging of playlist tracks."""
 
-    items: List[PlaylistTrack]
+    items: list[PlaylistTrack]
 
 
 class Playlist(Item):
@@ -76,15 +78,15 @@ class Playlist(Item):
     """
 
     collaborative: bool
-    description: Optional[str]
+    description: str | None
     external_urls: dict
-    images: Optional[List[Image]]
+    images: list[Image] | None
     name: str
     owner: PublicUser
-    public: Optional[bool]
+    public: bool | None
     snapshot_id: str
 
-    primary_color: Optional[str]
+    primary_color: str | None
 
 
 class SimplePlaylist(Playlist):
@@ -103,4 +105,4 @@ class FullPlaylist(Playlist):
 class SimplePlaylistPaging(OffsetPaging):
     """Paging of simplified playlists."""
 
-    items: List[Optional[SimplePlaylist]]
+    items: list[SimplePlaylist | None]

--- a/src/tekore/_model/recommendations.py
+++ b/src/tekore/_model/recommendations.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from __future__ import annotations
 
 from .base import Identifiable
 from .serialise import Model, StrEnum
@@ -29,7 +29,7 @@ class RecommendationSeed(Identifiable):
 
     afterFilteringSize: int
     afterRelinkingSize: int
-    href: Optional[str]
+    href: str | None
     initialPoolSize: int
     type: str
 
@@ -37,5 +37,5 @@ class RecommendationSeed(Identifiable):
 class Recommendations(Model):
     """Track recommendations."""
 
-    seeds: List[RecommendationSeed]
-    tracks: List[FullTrack]
+    seeds: list[RecommendationSeed]
+    tracks: list[FullTrack]

--- a/src/tekore/_model/show/__init__.py
+++ b/src/tekore/_model/show/__init__.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import List
 
 from ..paging import OffsetPaging
 from ..serialise import Model
@@ -18,7 +17,7 @@ class SimpleShow(Show):
 class SimpleShowPaging(OffsetPaging):
     """Paging of simplified shows."""
 
-    items: List[SimpleShow]
+    items: list[SimpleShow]
 
 
 class SavedShow(Model):
@@ -31,4 +30,4 @@ class SavedShow(Model):
 class SavedShowPaging(OffsetPaging):
     """Paging of shows in library."""
 
-    items: List[SavedShow]
+    items: list[SavedShow]

--- a/src/tekore/_model/show/base.py
+++ b/src/tekore/_model/show/base.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from __future__ import annotations
 
 from pydantic import Field
 
@@ -13,16 +13,16 @@ class Show(Item):
     :attr:`publisher` being an object is undocumented.
     """
 
-    available_markets: List[str] = Field(default_factory=list)
-    copyrights: List[Copyright]
+    available_markets: list[str] = Field(default_factory=list)
+    copyrights: list[Copyright]
     description: str
     explicit: bool
     external_urls: dict
-    html_description: Optional[str] = None
-    images: List[Image]
-    is_externally_hosted: Optional[bool]
-    languages: List[str]
+    html_description: str | None = None
+    images: list[Image]
+    is_externally_hosted: bool | None
+    languages: list[str]
     media_type: str
     name: str
-    publisher: Union[str, dict]
-    total_episodes: Optional[int] = None
+    publisher: str | dict
+    total_episodes: int | None = None

--- a/src/tekore/_model/show/full.py
+++ b/src/tekore/_model/show/full.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from ..episode import SimpleEpisodePaging
 from ..show import Show
@@ -12,4 +12,4 @@ class FullShow(Show):
     so it might be missing or removed in a future version.
     """
 
-    episodes: Optional[SimpleEpisodePaging] = None
+    episodes: SimpleEpisodePaging | None = None

--- a/src/tekore/_model/track.py
+++ b/src/tekore/_model/track.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import datetime
-from typing import List, Optional
 
 from .album import SimpleAlbum
 from .artist import SimpleArtist
@@ -18,18 +19,18 @@ class TrackLink(Item):
 class Track(Item):
     """Track base."""
 
-    artists: List[SimpleArtist]
-    available_markets: Optional[List[str]] = None
+    artists: list[SimpleArtist]
+    available_markets: list[str] | None = None
     disc_number: int
     duration_ms: int
     explicit: bool
     external_urls: dict
     is_local: bool
-    is_playable: Optional[bool] = None
-    linked_from: Optional[TrackLink] = None
+    is_playable: bool | None = None
+    linked_from: TrackLink | None = None
     name: str
-    preview_url: Optional[str] = None
-    restrictions: Optional[Restrictions] = None
+    preview_url: str | None = None
+    restrictions: Restrictions | None = None
     track_number: int
 
 
@@ -62,13 +63,13 @@ class FullTrack(Track):
 class FullTrackPaging(OffsetPaging):
     """Paging of full tracks."""
 
-    items: List[FullTrack]
+    items: list[FullTrack]
 
 
 class SimpleTrackPaging(OffsetPaging):
     """Paging of simplified tracks."""
 
-    items: List[SimpleTrack]
+    items: list[SimpleTrack]
 
 
 class Tracks(Model):
@@ -88,4 +89,4 @@ class SavedTrack(Model):
 class SavedTrackPaging(OffsetPaging):
     """Paging of tracks in library."""
 
-    items: List[SavedTrack]
+    items: list[SavedTrack]

--- a/src/tekore/_model/user.py
+++ b/src/tekore/_model/user.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from __future__ import annotations
 
 from .base import Item
 from .member import Followers, Image
@@ -21,9 +21,9 @@ class User(Item):
     """
 
     external_urls: dict
-    display_name: Optional[str] = None
-    followers: Optional[Followers] = None
-    images: Optional[List[Image]] = None
+    display_name: str | None = None
+    followers: Followers | None = None
+    images: list[Image] | None = None
 
 
 class PrivateUser(User):
@@ -37,11 +37,11 @@ class PrivateUser(User):
     ``user-read-birthdate`` scope was granted to the token.
     """
 
-    country: Optional[str] = None
-    email: Optional[str] = None
-    explicit_content: Optional[ExplicitContent] = None
-    product: Optional[str] = None
-    birthday: Optional[str] = None
+    country: str | None = None
+    email: str | None = None
+    explicit_content: ExplicitContent | None = None
+    product: str | None = None
+    birthday: str | None = None
 
 
 class PublicUser(User):

--- a/src/tekore/_sender/base.py
+++ b/src/tekore/_sender/base.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from collections.abc import Coroutine
 from dataclasses import dataclass
-from typing import Coroutine, Optional, Union
 
 
 @dataclass
@@ -9,11 +11,11 @@ class Request:
 
     method: str
     url: str
-    params: Optional[dict] = None
-    headers: Optional[dict] = None
-    data: Optional[dict] = None
-    json: Optional[dict] = None
-    content: Optional[str] = None
+    params: dict | None = None
+    headers: dict | None = None
+    data: dict | None = None
+    json: dict | None = None
+    content: str | None = None
 
 
 @dataclass
@@ -23,7 +25,7 @@ class Response:
     url: str
     headers: dict
     status_code: int
-    content: Optional[dict]
+    content: dict | None
 
 
 class Sender(ABC):
@@ -35,7 +37,7 @@ class Sender(ABC):
     @abstractmethod
     def send(
         self, request: Request
-    ) -> Union[Response, Coroutine[None, None, Response]]:
+    ) -> Response | Coroutine[None, None, Response]:
         """
         Send a request.
 
@@ -56,5 +58,5 @@ class Sender(ABC):
         """Sender asynchronicity mode."""
 
     @abstractmethod
-    def close(self) -> Union[None, Coroutine[None, None, None]]:
+    def close(self) -> None | Coroutine[None, None, None]:
         """Close underlying client."""

--- a/src/tekore/_sender/client.py
+++ b/src/tekore/_sender/client.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
 from functools import wraps
-from typing import Callable, Coroutine, Optional, Union
 from warnings import warn
 
 from .base import Request, Response
@@ -25,7 +27,7 @@ class Client(ExtendingSender):
         if they are in conflict and instantiates a sender of the requested type
     """
 
-    def __init__(self, sender: Optional[Sender], asynchronous: bool = None):
+    def __init__(self, sender: Sender | None, asynchronous: bool | None = None):
         super().__init__(sender)
 
         if self.sender.is_async and asynchronous is False:
@@ -43,7 +45,7 @@ class Client(ExtendingSender):
 
     def send(
         self, request: Request
-    ) -> Union[Response, Coroutine[None, None, Response]]:
+    ) -> Response | Coroutine[None, None, Response]:
         """Send request with underlying sender."""
         return self.sender.send(request)
 

--- a/src/tekore/_sender/concrete.py
+++ b/src/tekore/_sender/concrete.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from httpx import AsyncClient, Client
 from httpx import Response as HTTPXResponse
@@ -6,7 +6,7 @@ from httpx import Response as HTTPXResponse
 from .base import Request, Response, Sender
 
 
-def try_parse_json(response: HTTPXResponse) -> Optional[dict]:
+def try_parse_json(response: HTTPXResponse) -> dict | None:
     """Parse json content or return None if not successful."""
     try:
         return response.json()
@@ -30,7 +30,7 @@ class SyncSender(Sender):
         :class:`httpx.Client` to use when sending requests
     """
 
-    def __init__(self, client: Client = None):
+    def __init__(self, client: Client | None = None):
         self.client = client or Client()
 
     def send(self, request: Request) -> Response:
@@ -77,7 +77,7 @@ class AsyncSender(Sender):
         :class:`httpx.AsyncClient` to use when sending requests
     """
 
-    def __init__(self, client: AsyncClient = None):
+    def __init__(self, client: AsyncClient | None = None):
         self.client = client or AsyncClient()
 
     async def send(self, request: Request) -> Response:


### PR DESCRIPTION
* Tear out deprecated Typing aliases
* Tear out old ways to define Unions and Optionals
* Fix some wrong types while at it
* Python version bumped up to current 3.9 and 3.12 and 3.13 are now explicitly supported

- [ ] Tests written with 100% coverage
- [ ] Documentation and changelog entry written
- [ ] All `tox` checks passed with an appropriately configured
  [environment](https://github.com/felix-hilden/tekore#running-tests)
